### PR TITLE
Add "wave" visualizer idea and more improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     
     h1 {
       text-align: center;
+      font-size: 24px;
     }
     
     button:hover {
@@ -52,8 +53,8 @@
     */
     
     #canvasContainer {
-      width: 50vw;
-      height: 60vh;
+      width: 80vw;
+      height: 80vh;
       border: 1px solid #ccc;
       margin: 0 auto;
     }
@@ -115,6 +116,7 @@
           <option> circular-cubes </option>
           <option> blob </option>
           <option> spheres </option>
+          <option> waves </option>
         </select>
       </div>
       <div id='toggleRecording'>

--- a/index.html
+++ b/index.html
@@ -9,11 +9,19 @@
   <style>
     body {
       font-family: Arial;
+      letter-spacing: 1px;
+    }
+    
+    header {
+      display: flex;
+      justify-content: center;
+      align-items: center;
     }
     
     h1 {
-      text-align: center;
       font-size: 24px;
+      margin-right: auto;
+      font-weight: normal;
     }
     
     button:hover {
@@ -22,35 +30,19 @@
     
     button {
       padding: 3px;
+      margin: 3px;
     }
-    
-    /*
-    #audioFileName:before {
-      content: "Now playing: ";
-    }*/
     
     #audioFileName {
       width: fit-content;
-      /* 
-      animation: marquee 10s linear infinite;
-      font-weight: bold;
-      */
     }
     
     .marquee {
       margin: 0 auto;
       overflow: hidden;
-      /* width: 20%; */
       position: relative;
       white-space: nowrap;
     }
-    
-    /*
-    @keyframes marquee {
-      0% {transform: translateX(100%);}
-      100% {transform: translateX(-100%);}
-    }
-    */
     
     #canvasContainer {
       width: 80vw;
@@ -69,10 +61,58 @@
       align-items: center;
     }
     
+    #showDrawer {
+      margin-right: auto;
+    }
+    
+    #showDrawer, #hideDrawer {
+      background-color: transparent;
+      border: 1px solid transparent;
+      transition: 0.2s;
+    }
+    
+    #showDrawer:hover, #hideDrawer:hover {
+      border: 1px solid #ddd;
+      border-radius: 5px;
+    }
+    
+    #drawerHeader {
+      display: flex;
+      align-items: center;
+      padding-right: 5px;
+      border-bottom: 1px solid #ddd;
+    }
+    
+    #drawerHeader h1 {
+      margin-left: auto;
+    }
+    
+    #lightingControlHeader {
+      padding-left: 10px;
+      font-weight: bold;
+    }
+    
     .content {
       padding: 10px;
       display: flex;
       flex-direction: column;
+    }
+    
+    .drawer {
+      height: 100vh;
+      width: 15vw;
+      border-right: 1px solid #ddd;
+      background-color: #fff;
+      display: none;
+      position: absolute;
+      top: 0;
+      left: 0;
+      z-index: 10;
+    }
+    
+    .drawer h1 {
+      font-size: 20px;
+      padding: 3px;
     }
     
     .toolbar {
@@ -89,17 +129,90 @@
     .visualizer-section p {
       font-weight: bold;
     }
+    
+    .colorPicker, .lightAxis {
+      margin: 9px;
+      display: flex;
+      align-items: center;
+      gap: 1em;
+    }
+    
+    .colorPicker input {
+      background-color: transparent;
+      border: none;
+    }
   </style>
 </head>
 
 <body>
-  <h1> music visualizer </h1>
+  <header>
+    <button id='showDrawer'>
+      <!-- icon from https://iconoir.com/ -->
+      <svg width="24px" height="24px" stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" color="#000000">
+        <path d="M3 5H21" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+        <path d="M3 12H21" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+        <path d="M3 19H21" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+      </svg>
+    </button>
+    <h1> music visualizer </h1>
+  </header>
+  
   <main class='content'>
     <p id='loadingMsg'>Loading...</p>
     <div id='canvasContainer'></div>
     
     <div class='marquee'>
       <p id='audioFileName'></p>
+    </div>
+    
+    <div class='drawer'>
+      <div id='drawerHeader'>
+        <h1> options </h1>
+        <button id='hideDrawer'>
+          <!-- icon from https://iconoir.com/ -->
+          <svg width="24px" height="24px" stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" color="#000000">
+            <path d="M6.75827 17.2426L12.0009 12M17.2435 6.75736L12.0009 12M12.0009 12L6.75827 6.75736M12.0009 12L17.2435 17.2426" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+          </svg>
+        </button>
+      </div>
+      <div id='nonVisualizerSpecificOptions'>
+        <div class='colorPicker'>
+          <label for='bgColorPicker'>background color</label>
+          <input type='color' id='bgColorPicker' value='#111e37'>
+        </div>
+        
+        <!-- TODO: lighting controls -->
+        <div class='lightingControl'>
+          <p id='lightingControlHeader'> light controls </p>
+          
+          <div class='lightAxis'>
+            <label for='lightX'>x</label>
+            <input type='range' id='lightX' value='0' min='-50' max='50'>
+            <p id='lightXValue'>0</p>
+          </div>
+          
+          <div class='lightAxis'>
+            <label for='lightY'>y</label>
+            <input type='range' id='lightY' value='20' min='-50' max='50'>
+            <p id='lightYValue'>20</p>
+          </div>
+          
+          <div class='lightAxis'>
+            <label for='lightZ'>z</label>
+            <input type='range' id='lightZ' value='0' min='-50' max='50'>
+            <p id='lightZValue'>0</p>
+          </div>
+        </div>
+        
+        <!--
+        <div class='colorPicker'>
+          <label for="meshColor">visualizer color:</label>
+          <input type="color" id="meshColor" value="#ffffff">
+        </div>
+        -->
+      </div>
+      <div id='visualizerSpecificOptions'>
+      </div>
     </div>
     
     <div class='toolbar'>

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,6 +47,11 @@ const stopBtn = document.getElementById('stopVisualization');
 const vizSelect = document.getElementById('visualizerChoice');
 const toggleRecording = document.getElementById('toggleRecordingCheckbox');
 const loadingMsg = document.getElementById('loadingMsg');
+const drawer = document.querySelector('.drawer');
+const visualizerOptions = document.getElementById('visualizerSpecificOptions');
+const showDrawer = document.getElementById('showDrawer');
+const hideDrawer = document.getElementById('hideDrawer');
+const bgColorPicker = document.getElementById('bgColorPicker');
 
 // stuff for canvas recording
 // helpful! https://devtails.xyz/@adam/how-to-record-html-canvas-using-mediarecorder-and-export-as-video
@@ -95,6 +100,7 @@ function stopCanvasRecord(){
   }
 }
 
+// TODO: maybe have a scene manager so we can more easily change lighting and stuff
 function initializeScene(container: HTMLCanvasElement): ISceneComponents {
   const scene = new Scene();
   scene.background = new Color(0x111e37); //new Color(0xeeeeee);
@@ -208,18 +214,54 @@ function switchVisualizer(evt: Event){
   }
 }
 
+// assuming only one light
+function updateSceneLighting(scene: Scene, axis: string, val: number){
+  const light = scene.children.find(x => x.type === 'SpotLight');
+  if(light){
+    if(axis === 'lightX'){
+      light.position.x = val;
+    }else if(axis === 'lightY'){
+      light.position.y = val;
+    }else if(axis === 'lightZ'){
+      light.position.z = val;
+    }
+  }
+}
+
 // start
 if(importAudioBtn) audioManager.setupInput((importAudioBtn as HTMLButtonElement));
 audioManager.loadExample();
 
-// setup some event listeners
+// setup some event listeners for buttons
 playBtn?.addEventListener('click', playVisualization);
 stopBtn?.addEventListener('click', stopVisualization);
 vizSelect?.addEventListener('change', switchVisualizer);
 toggleRecording?.addEventListener(
   'change', () => recordingOn = !recordingOn
 );
+showDrawer?.addEventListener('click', () => {
+  if(drawer) drawer.style.display = 'block';
+});
+hideDrawer?.addEventListener('click', () => {
+  if(drawer) drawer.style.display = 'none'; 
+});
+bgColorPicker?.addEventListener('change', (evt: Event) => {
+  if(scene) scene.background = new Color(evt.target.value);
+});
+['lightX', 'lightY', 'lightZ'].forEach(axis => {
+  const control = document.getElementById(axis);
+  if(control){
+    control.addEventListener('input', (evt: Event) => {
+      const val = evt.target.value;
+      const text = document.getElementById(`${axis}Value`);
+      if(text) text.textContent = `${val}`;
+      
+      updateSceneLighting(scene, axis, val);
+    });
+  }
+});
 
+// 3d stuff setup
 const { renderer, scene, camera } = initializeScene((canvasContainer as HTMLCanvasElement));
 
 // stuff has loaded, hide loading message

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import { Pixels } from './visualizations/Pixels';
 import { CircularCubes } from './visualizations/CircularCubes';
 import { Blob as AnimatedBlob } from './visualizations/Blob';
 import { Spheres } from './visualizations/Spheres';
+import { Waves } from './visualizations/Waves';
 
 // important scene-related objects we might need to pass around
 interface ISceneComponents {
@@ -196,6 +197,10 @@ function switchVisualizer(evt: Event){
       break;
     case 'spheres':
       visualizer = new Spheres('spheres', clock, scene, audioManager, 50);
+      visualizer.init();
+      break;
+    case 'waves':
+      visualizer = new Waves('waves', clock, scene, audioManager, 50);
       visualizer.init();
       break;
     default:

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,7 +48,7 @@ const vizSelect = document.getElementById('visualizerChoice');
 const toggleRecording = document.getElementById('toggleRecordingCheckbox');
 const loadingMsg = document.getElementById('loadingMsg');
 const drawer = document.querySelector('.drawer');
-const visualizerOptions = document.getElementById('visualizerSpecificOptions');
+//const visualizerOptions = document.getElementById('visualizerSpecificOptions');
 const showDrawer = document.getElementById('showDrawer');
 const hideDrawer = document.getElementById('hideDrawer');
 const bgColorPicker = document.getElementById('bgColorPicker');
@@ -240,19 +240,21 @@ toggleRecording?.addEventListener(
   'change', () => recordingOn = !recordingOn
 );
 showDrawer?.addEventListener('click', () => {
-  if(drawer) drawer.style.display = 'block';
+  if(drawer) (drawer as HTMLElement).style.display = 'block';
 });
 hideDrawer?.addEventListener('click', () => {
-  if(drawer) drawer.style.display = 'none'; 
+  if(drawer) (drawer as HTMLElement).style.display = 'none'; 
 });
 bgColorPicker?.addEventListener('change', (evt: Event) => {
-  if(scene) scene.background = new Color(evt.target.value);
+  const target = evt.target as HTMLInputElement;
+  if(scene && target) scene.background = new Color(target.value);
 });
 ['lightX', 'lightY', 'lightZ'].forEach(axis => {
   const control = document.getElementById(axis);
   if(control){
     control.addEventListener('input', (evt: Event) => {
-      const val = evt.target.value;
+      const target = evt.target as HTMLInputElement;
+      const val = parseInt(target.value);
       const text = document.getElementById(`${axis}Value`);
       if(text) text.textContent = `${val}`;
       

--- a/src/visualizations/Waves.ts
+++ b/src/visualizations/Waves.ts
@@ -72,7 +72,7 @@ export class Waves extends VisualizerBase {
       // set column colors as gradient?
       
       //let deg = 0;
-      const maxY = 10;
+      //const maxY = 10;
       
       for(let i = 0; i < bufferLen; i += increment){
         const newCube = createVisualizationCube();
@@ -129,7 +129,7 @@ export class Waves extends VisualizerBase {
       const lerpAmount = (elapsedTime - this.lastTime) / timeInterval;
       
       const cols = this.visualization.children;
-      for(let col of cols){
+      for(const col of cols){
         for(let i = 0; i < numObjects; i++){
           const value = buffer[i * increment] / 255;
           const newVal = value * 12;

--- a/src/visualizations/Waves.ts
+++ b/src/visualizations/Waves.ts
@@ -53,7 +53,7 @@ export class Waves extends VisualizerBase {
     const increment = Math.floor(bufferLen / numObjects);
 
     function createVisualizationCube(){
-      const boxGeometry = new BoxGeometry(0.2, 0.4, 0.4);
+      const boxGeometry = new BoxGeometry(0.2, 0.4, 0.2);
       const boxMaterial = new MeshPhongMaterial({color: '#ffffdd'}); // TODO: color gradient?
       const box = new Mesh(boxGeometry, boxMaterial);
       box.receiveShadow = true;
@@ -154,6 +154,9 @@ export class Waves extends VisualizerBase {
     }
     
     this.visualization.position.z += 0.04;
+    
+    // TODO: this isn't great, can we have a smoother reset? or maybe just keep moving rows from front to back as they get away from the camera.
+    // reset position of visualization after it moves far enough that there's not much of it left in the viewport
     if(this.visualization.position.z > 100){
       this.visualization.position.z = -50;
     }

--- a/src/visualizations/Waves.ts
+++ b/src/visualizations/Waves.ts
@@ -1,0 +1,161 @@
+import { VisualizerBase } from './VisualizerBase';
+
+import { AudioManager } from '../AudioManager';
+
+import {
+  Scene, 
+  Mesh,
+  BoxGeometry,
+  MeshPhongMaterial,
+  Vector3,
+  Group,
+  Clock,
+} from 'three';
+
+export class Waves extends VisualizerBase {
+  numObjects: number;
+  visualization: Group;
+  columns: number;
+  clock: Clock;
+  lastTime: number;
+  scaleTo: number[];
+  
+  constructor(
+    name: string, 
+    clock: Clock, 
+    scene: Scene, 
+    audioManager: AudioManager, 
+    size: number,
+    columns?: number
+  ){
+    super(name, scene, audioManager);
+    this.numObjects = size;
+    this.visualization = new Group();
+    this.clock = clock;
+    this.lastTime = clock.getElapsedTime();
+    this.scaleTo = [];
+    this.columns = columns || 10;
+  }
+  
+  init(){
+    // clear the scene
+    this.scene.children.forEach(c => {
+      if(
+        !c.type.toLowerCase().includes('camera') && 
+        !c.type.toLowerCase().includes('light'))
+      {  
+        this.scene.remove(c);
+      }
+    });
+    
+    const bufferLen = this.audioManager.analyser.frequencyBinCount;
+    const numObjects = this.numObjects;
+    const increment = Math.floor(bufferLen / numObjects);
+
+    function createVisualizationCube(){
+      const boxGeometry = new BoxGeometry(0.2, 0.4, 0.4);
+      const boxMaterial = new MeshPhongMaterial({color: '#ffffdd'}); // TODO: color gradient?
+      const box = new Mesh(boxGeometry, boxMaterial);
+      box.receiveShadow = true;
+      box.castShadow = true;
+      return box;
+    }
+    
+    let currZ = 0;
+    
+    for(let c = 0; c < this.columns; c++){
+      const newCol = new Group();
+      
+      let currX = -30;
+      
+      // TODO:
+      // set column colors as gradient?
+      
+      //let deg = 0;
+      const maxY = 10;
+      
+      for(let i = 0; i < bufferLen; i += increment){
+        const newCube = createVisualizationCube();
+        
+        newCube.position.x = currX;
+        newCube.position.z = currZ;
+        newCube.position.y = 0;//Math.sin(Math.PI * deg / 180) * maxY;
+
+        newCol.add(newCube);
+        
+        currX += 3;
+        //deg += (360 / numObjects);
+      }
+      
+      this.visualization.add(newCol);
+      
+      currZ -= 10;
+    }
+    
+    this.scene.add(this.visualization);
+    this.visualization.position.z = -50;
+    this.visualization.position.x += 50;
+    this.visualization.position.y -= 5;
+    this.visualization.rotateY(Math.PI / 2);
+  }
+  
+  update(){
+    const elapsedTime = this.clock.getElapsedTime();
+    
+    const bufferLength = this.audioManager.analyser.frequencyBinCount;
+    const buffer = this.audioManager.buffer;
+    const numObjects = this.numObjects;
+    const increment = Math.floor(bufferLength / numObjects);
+    
+    this.audioManager.analyser.getByteFrequencyData(buffer); //getByteTimeDomainData is cool too! :D
+    
+    const scaleToIsEmpty = this.scaleTo.length === 0;
+    const timeInterval = 0.02;
+    
+    if(elapsedTime - this.lastTime >= timeInterval){
+      this.lastTime = elapsedTime;
+      
+      for(let i = 0; i < numObjects; i++){
+        const value = buffer[i * increment] / 255;
+        const newVal = value * 12;
+
+        if(scaleToIsEmpty){
+          this.scaleTo.push(newVal);
+        }else{
+          this.scaleTo[i] = newVal;
+        }
+      }
+    }else{
+      const lerpAmount = (elapsedTime - this.lastTime) / timeInterval;
+      
+      const cols = this.visualization.children;
+      for(let col of cols){
+        for(let i = 0; i < numObjects; i++){
+          const value = buffer[i * increment] / 255;
+          const newVal = value * 12;
+          const obj = col.children[i];
+          
+          let valToScaleTo;
+          
+          if(scaleToIsEmpty){
+            this.scaleTo.push(newVal);
+            valToScaleTo = newVal;
+          }else{
+            valToScaleTo = this.scaleTo[i];
+          }
+        
+          obj.position.lerpVectors(
+            obj.position, 
+            new Vector3(obj.position.x, valToScaleTo, obj.position.z), 
+            lerpAmount,
+          );
+        }
+      }
+    }
+    
+    this.visualization.position.z += 0.04;
+    if(this.visualization.position.z > 100){
+      this.visualization.position.z = -50;
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new "wave" visualizer idea (although it needs improvement) + a toggleable drawer for configurable parameters! (but right now just scene bg color and spotlight position) + some ui adjustments (mainly font size/spacing, enlarged the display canvas)

"wave" visualizer idea:
![24-10-2024_200659](https://github.com/user-attachments/assets/66b18147-c5b6-4b56-80f6-896402cce699)

new hamburger menu icon on top left:
![image](https://github.com/user-attachments/assets/dba6fb3e-5fd8-404c-a9bd-3f6c392261f2)

when drawer is open:
![image](https://github.com/user-attachments/assets/ef065b59-a496-4feb-ac38-87edf424a29c)

bg color picker:
![image](https://github.com/user-attachments/assets/4249783a-b1da-449c-bc21-bbee9cc64301)

