### PR TITLE
make post-processing effects available for all visualizers + UI edits

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <style>
     body {
       font-family: Arial;
-      letter-spacing: 1px;
+      letter-spacing: 0.06em;
     }
     
     header {
@@ -136,6 +136,10 @@
       gap: 0.8em;
     }
     
+    #nonVisualizerSpecificOptions .input input:not([type=range]) {
+      margin-left: auto;
+    }
+    
     .toggleWireframe {
       margin: 10px;
       display: flex;
@@ -153,6 +157,10 @@
       display: flex;
       align-items: center;
       gap: 8px;
+    }
+    
+    .fftSizeDropdown select {
+      margin-left: auto;
     }
     
   </style>
@@ -189,6 +197,7 @@
           </svg>
         </button>
       </div>
+      
       <div id='nonVisualizerSpecificOptions'>
         <div class='input colorPicker'>
           <label for='bgColorPicker'>background color</label>
@@ -200,7 +209,7 @@
           <input type='color' id='vizColorPicker' value=''>
         </div>
         
-        <div class='toggleWireframe'>
+        <div class='input toggleWireframe'>
           <label for='toggleWireframeInput'>wireframe</label>
           <input type='checkbox' id='toggleWireframeInput'>
         </div>
@@ -208,6 +217,14 @@
         <!-- fftSize dropdown for AnalyserNode -->
         <div class='fftSizeDropdown'>
           <label for='fftSizeSelect'>fft size</label>
+          <!-- icon from https://iconoir.com/ -->
+          <a href='https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode/fftSize' target='_blank'>
+            <svg width="18px" height="18px" stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" color="#000000">
+              <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              <path d="M9 9C9 5.49997 14.5 5.5 14.5 9C14.5 11.5 12 10.9999 12 13.9999" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+              <path d="M12 18.01L12.01 17.9989" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+          </a>
           <select id='fftSizeSelect'>
             <option>32</option>
             <option>64</option>
@@ -218,14 +235,6 @@
             <option selected>2048</option>
             <option>4096</option>
           </select>
-          <!-- icon from https://iconoir.com/ -->
-          <a href='https://developer.mozilla.org/en-US/docs/Web/API/AnalyserNode/fftSize' target='_blank'>
-            <svg width="24px" height="24px" stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" color="#000000">
-              <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-              <path d="M9 9C9 5.49997 14.5 5.5 14.5 9C14.5 11.5 12 10.9999 12 13.9999" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-              <path d="M12 18.01L12.01 17.9989" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-            </svg>
-          </a>
         </div>
         
         <!-- lighting controls -->

--- a/src/main.ts
+++ b/src/main.ts
@@ -317,5 +317,6 @@ if(loadingMsg) loadingMsg.style.display = 'none';
 
 visualizer = new Waveform('waveform', sceneManager, audioManager, 50);
 visualizer.init();
+displayVisualizerConfigurableParams(visualizer);
 
 update();

--- a/src/visualizations/Blob.ts
+++ b/src/visualizations/Blob.ts
@@ -219,5 +219,7 @@ export class Blob extends VisualizerBase {
     (this.visualization.material as ShaderMaterial).uniforms.u_frequency.value = avgFreq;
     
     this.visualization.rotateY(Math.PI / 2500);
+    
+    this.doPostProcessing();
   }
 }

--- a/src/visualizations/CircularCubes.ts
+++ b/src/visualizations/CircularCubes.ts
@@ -128,5 +128,7 @@ export class CircularCubes extends VisualizerBase {
     }
     
     this.visualization.rotateY(Math.PI / 2500);
+    
+    this.doPostProcessing();
   }
 }

--- a/src/visualizations/Spheres.ts
+++ b/src/visualizations/Spheres.ts
@@ -142,5 +142,7 @@ export class Spheres extends VisualizerBase {
     }
     
     this.visualization.rotateZ(Math.PI / 500);
+    
+    this.doPostProcessing();
   }
 }

--- a/src/visualizations/Starfield.ts
+++ b/src/visualizations/Starfield.ts
@@ -7,15 +7,8 @@ import {
   Vector3,
   Group,
   Quaternion,
-  Vector2,
   MeshStandardMaterial,
 } from 'three';
-
-import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
-import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
-import { FXAAShader } from 'three/addons/shaders/FXAAShader.js';
-import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
-import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
 
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
@@ -28,7 +21,6 @@ export class Starfield extends VisualizerBase {
   numObjects: number;
   visualization: Group;
   loader: GLTFLoader;
-  composer: EffectComposer; // TODO: should effects be within SceneManager so we can apply to any visualizer?
   xMin: number;
   xMax: number;
   yMin: number;
@@ -50,7 +42,6 @@ export class Starfield extends VisualizerBase {
     this.numObjects = size;
     this.visualization = new Group();
     this.loader = new GLTFLoader();
-    this.composer = new EffectComposer(this.renderer);
     this.xMin = xMin || -50;
     this.xMax = xMax || 50;
     this.yMin = yMin || -20;
@@ -153,32 +144,7 @@ export class Starfield extends VisualizerBase {
       this.visualization.add(star);
     }
     
-    // glow effect stuff (Bloom effect)
-    const container = this.renderer.domElement;
-    
-    if(container){
-      const renderScene = new RenderPass(this.scene, this.camera);
-      
-      const effectFXAA = new ShaderPass(FXAAShader);
-      effectFXAA.uniforms['resolution'].value.set(
-        1 / container.clientWidth, 
-        1 / container.clientHeight
-      );
-
-      const bloomPass = new UnrealBloomPass(
-        new Vector2(container.clientWidth, container.clientHeight),
-        0.9, //0.25, // bloom strength
-        0.9, //0.1, // bloom radius
-        0.08,        // bloom threshold
-      );
-
-      this.composer.setSize(container.clientWidth, container.clientHeight);
-      this.composer.addPass(renderScene);
-      this.composer.addPass(effectFXAA);
-      this.composer.addPass(bloomPass);
-      
-      this.scene.add(this.visualization);
-    }
+    this.scene.add(this.visualization);
   }
   
   update(){
@@ -211,6 +177,7 @@ export class Starfield extends VisualizerBase {
     
     this.camera.translateZ(-0.01); // move camera forward a bit
     this.camera.rotateZ(-Math.PI / 2500); // rotate the camera 
-    this.composer.render(); // update bloom filter
+    
+    this.doPostProcessing();
   }
 }

--- a/src/visualizations/VisualizerBase.ts
+++ b/src/visualizations/VisualizerBase.ts
@@ -3,7 +3,16 @@ import {
   Camera,
   Clock,
   WebGLRenderer,
+  Vector2,
 } from 'three';
+
+import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
+import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
+import { FXAAShader } from 'three/addons/shaders/FXAAShader.js';
+import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+import { AfterimagePass } from 'three/addons/postprocessing/AfterimagePass.js';
+import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 
 import { SceneManager } from '../SceneManager';
 import { AudioManager } from '../AudioManager';
@@ -29,6 +38,10 @@ export class VisualizerBase {
   scene: Scene;
   camera: Camera;
   renderer: WebGLRenderer;
+  composer: EffectComposer;
+  bloomPass: UnrealBloomPass;
+  afterimagePass: AfterimagePass;
+  outputPass: OutputPass;
   configurableParams: Record<string, ConfigurableParameterRange | ConfigurableParameterToggle>;
   
   constructor(name: string, sceneManager: SceneManager, audioManager: AudioManager){
@@ -39,7 +52,91 @@ export class VisualizerBase {
     this.clock = sceneManager.clock;
     this.camera = sceneManager.camera;
     this.renderer = sceneManager.renderer;
-    this.configurableParams = {};
+    this.configurableParams = {
+      'bloomPass': {isOn: false},
+      'bloomStrength': {value: 0.8, min: 0, max: 2.0, step: 0.1},
+      'bloomRadius': {value: 1.0, min: 0, max: 2.0, step: 0.1},
+      'bloomThreshold': {value: 0.1, min: 0, max: 2.0, step: 0.1},
+      'afterimagePass': {isOn: false},
+      'afterimageDamp': {value: 0.5, min: 0, max: 1, step: 0.1},
+    };
+    
+    // post-processing effects
+    this.composer = new EffectComposer(this.renderer);
+    const container = this.renderer.domElement;
+    if(container){
+      const renderScene = new RenderPass(this.scene, this.camera);
+      
+      // important: order of addition of effects matters!
+      const effectFXAA = new ShaderPass(FXAAShader);
+      effectFXAA.uniforms['resolution'].value.set(
+        1 / container.clientWidth, 
+        1 / container.clientHeight
+      );
+      
+      this.composer.setSize(container.clientWidth, container.clientHeight);
+      this.composer.addPass(renderScene);
+      this.composer.addPass(effectFXAA);
+      
+      const afterimageDamp = this.configurableParams.afterimageDamp as ConfigurableParameterRange; 
+      this.afterimagePass = new AfterimagePass();
+      this.afterimagePass.uniforms.damp = {value: afterimageDamp.value};
+      this.afterimagePass.enabled = false;
+      this.composer.addPass(this.afterimagePass);
+      
+      this.outputPass = new OutputPass();
+      this.outputPass.enabled = false;
+      this.composer.addPass(this.outputPass);
+
+      const strength = this.configurableParams.bloomStrength as ConfigurableParameterRange;
+      const radius = this.configurableParams.bloomRadius as ConfigurableParameterRange;
+      const threshold = this.configurableParams.bloomThreshold as ConfigurableParameterRange;
+      
+      this.bloomPass = new UnrealBloomPass(
+        new Vector2(container.clientWidth, container.clientHeight),
+        strength.value,
+        radius.value,
+        threshold.value,
+      );
+      this.bloomPass.enabled = false;
+      
+      this.composer.addPass(this.bloomPass);
+    }
+  }
+  
+  doPostProcessing(){
+    const afterimagePass = this.configurableParams.afterimagePass as ConfigurableParameterToggle;
+    const bloomPass = this.configurableParams.bloomPass as ConfigurableParameterToggle;
+    
+    // bloom pass params
+    const strength = this.configurableParams.bloomStrength as ConfigurableParameterRange;
+    const radius = this.configurableParams.bloomRadius as ConfigurableParameterRange;
+    const threshold = this.configurableParams.bloomThreshold as ConfigurableParameterRange;
+    
+    if(afterimagePass.isOn){
+      // afterimage pass params
+      const afterimageDamp = this.configurableParams.afterimageDamp as ConfigurableParameterRange;
+      this.afterimagePass.uniforms.damp = {value: afterimageDamp.value};
+    
+      this.afterimagePass.enabled = true;
+      this.outputPass.enabled = true;
+    }else{
+      this.afterimagePass.enabled = false;
+      this.outputPass.enabled = false;
+    }
+    
+    if(bloomPass.isOn){
+      this.bloomPass.enabled = true;
+      this.bloomPass.strength = strength.value;
+      this.bloomPass.radius = radius.value;
+      this.bloomPass.threshold = threshold.value;  
+    }else{
+      this.bloomPass.enabled = false;
+    }
+    
+    if(afterimagePass.isOn || bloomPass.isOn){
+      this.composer.render();
+    }
   }
 
   init(){

--- a/src/visualizations/Waveform.ts
+++ b/src/visualizations/Waveform.ts
@@ -132,5 +132,7 @@ export class Waveform extends VisualizerBase {
       const obj = this.visualization.children[i];
       obj.position.lerp(new Vector3(obj.position.x, y, obj.position.z), 0.5);
     }*/
+    
+    this.doPostProcessing();
   }
 }

--- a/src/visualizations/Waves.ts
+++ b/src/visualizations/Waves.ts
@@ -6,14 +6,6 @@ import {
 import { SceneManager } from '../SceneManager';
 import { AudioManager } from '../AudioManager';
 
-import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
-import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
-import { FXAAShader } from 'three/addons/shaders/FXAAShader.js';
-//import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
-import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
-import { AfterimagePass } from 'three/addons/postprocessing/AfterimagePass.js';
-import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
-
 /* 
 ideas:
 - opacity of cubes depends on distance to camera. the closer, the more transparent
@@ -37,8 +29,6 @@ export class Waves extends VisualizerBase {
   columns: number;
   lastTime: number;
   scaleTo: number[];
-  afterimagePass: AfterimagePass;
-  composer: EffectComposer;
   
   constructor(
     name: string, 
@@ -54,17 +44,16 @@ export class Waves extends VisualizerBase {
     this.scaleTo = [];
     this.columns = columns || 15; // TODO: make this configurable?
     
-    this.configurableParams = {
+    const params: Record<string, ConfigurableParameterRange | ConfigurableParameterToggle> = {
       'zSeparation': {value: -6, min: -10, max: -2, step: 1, doNotShow: true}, // TODO: not sure how to handle this one atm
       'xSeparation': {value: 6, min: 1, max: 10, step: 1, doNotShow: true},    // TODO: not sure how to handle this one atm
       'speed': {value: 0.1, min: 0, max: 0.5, step: 0.01},
       'yPos': {value: -2, min: -10, max: 10, step: 1},
-      'afterimagePassDamp': {value: 0.5, min: 0, max: 1, step: 0.1},
-      'postProcessing': {isOn: true},
     };
     
-    this.composer = new EffectComposer(this.renderer);
-    this.afterimagePass = new AfterimagePass();
+    Object.keys(params).forEach(p => this.configurableParams[p] = params[p]);
+    
+    (this.configurableParams.afterimagePass as ConfigurableParameterToggle).isOn = true;
   }
   
   init(){
@@ -84,7 +73,6 @@ export class Waves extends VisualizerBase {
     const xSeparation = params.xSeparation as ConfigurableParameterRange;
     const zSeparation = params.zSeparation as ConfigurableParameterRange;
     const yPos = params.yPos as ConfigurableParameterRange;
-    const afterimagePassDamp = params.afterimagePassDamp as ConfigurableParameterRange;
 
     function createVisualizationCube(): Mesh {
       const boxGeometry = new BoxGeometry(0.1, 0.1, 0.1);
@@ -125,41 +113,6 @@ export class Waves extends VisualizerBase {
     this.scene.add(this.visualization);
     
     this.visualization.position.y += yPos.value;
-    
-    // post-processing effects
-    const container = this.renderer.domElement;
-    if(container){
-      const renderScene = new RenderPass(this.scene, this.camera);
-      
-      const effectFXAA = new ShaderPass(FXAAShader);
-      effectFXAA.uniforms['resolution'].value.set(
-        1 / container.clientWidth, 
-        1 / container.clientHeight
-      );
-      
-      /*
-      const bloomPass = new UnrealBloomPass(
-        new Vector2(container.clientWidth, container.clientHeight),
-        0.5, //0.25, // bloom strength
-        0.5, //0.1, // bloom radius
-        0.01,        // bloom threshold
-      );*/
-      
-      this.composer.setSize(container.clientWidth, container.clientHeight);
-      this.composer.addPass(renderScene);      
-      this.composer.addPass(effectFXAA);
-      
-      this.composer.addPass(this.afterimagePass);
-      
-      const outputPass = new OutputPass();
-      this.composer.addPass(outputPass);
-      
-      this.afterimagePass.uniforms.damp = {value: afterimagePassDamp.value};
-      this.afterimagePass.enabled = true;
-      
-      // order of addition of effects matters!
-      //this.composer.addPass(bloomPass);
-    }
   }
   
   update(){
@@ -180,9 +133,7 @@ export class Waves extends VisualizerBase {
     const params = this.configurableParams;
     const zSeparation = params.zSeparation as ConfigurableParameterRange;
     const speed = params.speed as ConfigurableParameterRange;
-    const postProcessing = params.postProcessing as ConfigurableParameterToggle;
     const yPos = params.yPos as ConfigurableParameterRange;
-    const afterimagePassDamp = params.afterimagePassDamp as ConfigurableParameterRange;
     
     if(elapsedTime - this.lastTime >= timeInterval){
       this.lastTime = elapsedTime;
@@ -242,22 +193,13 @@ export class Waves extends VisualizerBase {
             cube.position.z = rows[idx - 1].children[0].position.z + zSeparation.value;
           }
         }
-        
-        //cube.rotation.y += 0.015;
-        //cube.rotation.x += 0.0075;
       }
     });
-    
-    //this.visualization.rotateZ(Math.PI / 1200);
     
     if(this.visualization.position.y !== yPos.value){
       this.visualization.position.y = yPos.value;
     }
-    
-    if(postProcessing.isOn){
-      this.afterimagePass.uniforms.damp = {value: afterimagePassDamp.value};
-      this.composer.render(); // update postprocessing composer
-    }
+    this.doPostProcessing();
   }
   
 }


### PR DESCRIPTION
- made some UI edits to better align the inputs (e.g. color pickers, checkbox, select) in the sidebar
- made bloom and afterimage post-processing effects available for all visualizations! (well, except the "pixels" one, which is just a shader really but I should make the effects available to that one too - I got lazy and didn't feel like checking lol, sorry)
  - the toggles for the post-processing stuff admittedly looks a bit not great. I'll look into improving that UI later hopefully. 

![image](https://github.com/user-attachments/assets/2be5d4eb-ebcb-4f61-b07e-3569f117f930)

![image](https://github.com/user-attachments/assets/841c8a13-6aba-471a-a81a-9e2953dc6c3b)

