### PR TITLE
Fixes n stuff

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ import { Orbits } from './visualizations/Orbits';
 let isPlaying = false;
 let visualizer: VisualizerBase | null = null;
 
+let isRecording = false;
 let recordingOn = false;
 let mediaRecorder: MediaRecorder | null = null;
 let capturedVideoChunks: Blob[] = [];
@@ -107,9 +108,10 @@ function playVisualization(){
   audioManager.play();
   isPlaying = true;
   
-  if(recordingOn){
+  if(recordingOn && !isRecording){
     console.log('starting record');
     startCanvasRecord(renderer);
+    isRecording = true;
   }
 }
 
@@ -117,9 +119,10 @@ function stopVisualization(){
   audioManager.stop();
   isPlaying = false;
   
-  if(recordingOn){
+  if(isRecording){
     console.log('stopping record');
     stopCanvasRecord();
+    isRecording = false;
   }
 }
 

--- a/src/visualizations/Lights.ts
+++ b/src/visualizations/Lights.ts
@@ -28,11 +28,11 @@ export class Lights extends VisualizerBase {
     this.scaleTo = [];
     
     this.configurableParams['speed'] = {
-      value: 20, 
-      min: 1, 
-      max: 80, 
-      step: 1
-    }; // TODO: this is actually inverted atm lol - smaller value == faster
+      value: 0.05, 
+      min: 0.01, 
+      max: 1.0, 
+      step: 0.01,
+    };
     
     (this.configurableParams.bloomPass as ConfigurableParameterToggle).isOn = true;
   }
@@ -145,9 +145,9 @@ export class Lights extends VisualizerBase {
       const speed = this.configurableParams.speed as ConfigurableParameterRange;
       
       // @ts-expect-error TS2339
-      c.position.x += c.velocity.x / speed.value; //20;
+      c.position.x += c.velocity.x * speed.value;
       // @ts-expect-error TS2339
-      c.position.y += c.velocity.y / speed.value; //20;
+      c.position.y += c.velocity.y * speed.value;
       
       // if child goes out of viewport, adjust
       //

--- a/src/visualizations/Orbits.ts
+++ b/src/visualizations/Orbits.ts
@@ -1,4 +1,4 @@
-import { VisualizerBase } from './VisualizerBase';
+import { ConfigurableParameterToggle, VisualizerBase } from './VisualizerBase';
 import { SceneManager } from '../SceneManager';
 import { AudioManager } from '../AudioManager';
 

--- a/src/visualizations/Orbits.ts
+++ b/src/visualizations/Orbits.ts
@@ -36,6 +36,8 @@ export class Orbits extends VisualizerBase {
     this.lastTime = this.clock.getElapsedTime();
     this.scaleTo = [];
     this.orbits = [];
+    
+    (this.configurableParams.bloomPass as ConfigurableParameterToggle).isOn = true;
   }
   
   init(){

--- a/src/visualizations/Orbits.ts
+++ b/src/visualizations/Orbits.ts
@@ -79,7 +79,7 @@ export class Orbits extends VisualizerBase {
         const randRotation = new Quaternion();
         randRotation.random();
         
-        const factor = Math.random();
+        const factor = Math.random(); // for randomizing speed
         
         return (time: number) => {
           const newXPos = majAxis * Math.cos(factor * time);
@@ -142,7 +142,9 @@ export class Orbits extends VisualizerBase {
       
       for(let i = 0; i < numObjects; i++){
         const value = buffer[i * increment] / 255;
-        const newVal = value * 12;
+        
+        // prevent scale from possibly being 0
+        const newVal = Math.max(value * 12, 0.001);
 
         if(scaleToIsEmpty){
           this.scaleTo.push(newVal);
@@ -162,7 +164,9 @@ export class Orbits extends VisualizerBase {
         
         if(scaleToIsEmpty){
           this.scaleTo.push(newVal);
-          valToScaleTo = newVal;
+          
+          // prevent scale from possibly being 0
+          valToScaleTo = Math.max(newVal, 0.001);
         }else{
           valToScaleTo = this.scaleTo[i];
         }


### PR DESCRIPTION
- fix recording logic so that if it was recording and the recording checkbox was unchecked, stopping play would still stop the recording. previously stopping the recording was based on the checkbox being checked 😬
- turn on bloom by default for the orbits visualizer
- fix scaling of the spheres in the orbits visualizer so that they can never reach 0 for scale (previously, depending on the audio it would've been possible for the scale value to be 0 for some spheres and that would effectively eliminate the number of spheres in the visualizer)