### PR TITLE
Add static image "visualizer"

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,6 +237,10 @@
           </select>
         </div>
         
+        <!-- allow user to import an image to be used as texture -->
+        <button id='importImage'> import image as texture </button>
+        <button id='removeImage'> clear texture </button>
+        
         <!-- lighting controls -->
         <div class='lightingControl'>
           <p id='lightingControlHeader'> light controls </p>

--- a/index.html
+++ b/index.html
@@ -284,6 +284,7 @@
           <option> waves </option>
           <option> lights </option>
           <option> orbits </option>
+          <option> image </option>
         </select>
       </div>
       <div id='toggleRecording'>

--- a/src/SceneManager.ts
+++ b/src/SceneManager.ts
@@ -9,6 +9,7 @@ import {
   Clock,
   Mesh,
   MeshStandardMaterial,
+  Texture,
 } from 'three';
 
 export class SceneManager {
@@ -17,6 +18,7 @@ export class SceneManager {
   camera: Camera;
   light: SpotLight;
   clock: Clock;
+  texture: Texture | null;
   
   constructor(container: HTMLCanvasElement){
     const scene = new Scene();
@@ -55,6 +57,8 @@ export class SceneManager {
     this.light = light;
     
     this.clock = new Clock();
+    
+    this.texture = null;
     
     renderer.render(scene, camera);    
   }
@@ -111,5 +115,45 @@ export class SceneManager {
         });
       }
     });
+  }
+  
+  updateTexture(texture: Texture | null){
+    if(texture !== null){
+      console.log("updating texture");
+      this.scene.children.forEach(child => {
+        if(child.type === 'Group'){
+          (child.children as Mesh[]).forEach(c => {
+            if(c.material){
+              (c.material as MeshStandardMaterial).map = texture;
+              (c.material as MeshStandardMaterial).needsUpdate = true;
+            }else if(c.children){
+              // TODO: recursively apply new color to children if Group is found
+              (c.children as Mesh[]).forEach(c2 => {
+                (c2.material as MeshStandardMaterial).map = texture;
+                (c.material as MeshStandardMaterial).needsUpdate = true;
+              });
+            }
+          });
+        }
+      });
+    }else if(texture === null){
+      // remove texture and set bg color
+      this.scene.children.forEach(child => {
+        if(child.type === 'Group'){
+          (child.children as Mesh[]).forEach(c => {
+            if(c.material){
+              (c.material as MeshStandardMaterial).map = null;
+              (c.material as MeshStandardMaterial).needsUpdate = true;
+            }else if(c.children){
+              // TODO: recursively apply new color to children if Group is found
+              (c.children as Mesh[]).forEach(c2 => {
+                (c2.material as MeshStandardMaterial).map = null;
+                (c.material as MeshStandardMaterial).needsUpdate = true;
+              });
+            }
+          });
+        }
+      });      
+    }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { 
   WebGLRenderer,
+  TextureLoader,
 } from 'three';
 
 import { SceneManager } from './SceneManager';
@@ -20,7 +21,7 @@ import { Spheres } from './visualizations/Spheres';
 import { Waves } from './visualizations/Waves';
 import { Lights } from './visualizations/Lights';
 import { Orbits } from './visualizations/Orbits';
-import { ImageVisualizer } from './visualizations/Image';
+import { ImagePlane } from './visualizations/Image';
 
 // global variables
 let isPlaying = false;
@@ -49,6 +50,8 @@ const bgColorPicker = document.getElementById('bgColorPicker');
 const vizColorPicker = document.getElementById('vizColorPicker');
 const fftSizeDropdown = document.getElementById('fftSizeSelect');
 const toggleWireframeCheckbox = document.getElementById('toggleWireframeInput');
+const importImage = document.getElementById('importImage');
+const removeImage = document.getElementById('removeImage');
 
 // stuff for canvas recording
 // helpful! https://devtails.xyz/@adam/how-to-record-html-canvas-using-mediarecorder-and-export-as-video
@@ -261,7 +264,7 @@ function switchVisualizer(evt: Event){
       visualizer.init();
       break;
     case 'image':
-      visualizer = new ImageVisualizer('imageVisualizer', sceneManager, audioManager);
+      visualizer = new ImagePlane('imagePlane', sceneManager, audioManager);
       visualizer.init();
       break;
     default:
@@ -325,6 +328,41 @@ fftSizeDropdown?.addEventListener('change', (evt: Event) => {
 
 toggleWireframeCheckbox?.addEventListener('change', () => {
   sceneManager.toggleWireframe();
+});
+
+importImage?.addEventListener('click', () => {
+  // import image, create texture, apply it to all children of scene via SceneManager
+  if(sceneManager){
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.addEventListener('change', getFile, false);
+    input.click();
+    
+    function getFile(e){
+        const img = new Image();
+        const reader = new FileReader();
+        const file = e.target.files[0];
+        
+        if(!file.type.match(/image.*/)){
+            console.log("not a valid image");
+            return;
+        }
+        
+        reader.onloadend = function(){
+          const newTexture = new TextureLoader().load(reader.result);
+          sceneManager.updateTexture(newTexture);
+        };
+        reader.readAsDataURL(file);
+    }
+  }
+});
+
+removeImage?.addEventListener('click', () => {
+  // remove texture from all children of scene via SceneManager
+  // set color of all children to current selected color
+  if(sceneManager){
+    sceneManager.updateTexture(null);
+  }
 });
 
 // 3d stuff setup

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import { Spheres } from './visualizations/Spheres';
 import { Waves } from './visualizations/Waves';
 import { Lights } from './visualizations/Lights';
 import { Orbits } from './visualizations/Orbits';
+import { ImageVisualizer } from './visualizations/Image';
 
 // global variables
 let isPlaying = false;
@@ -257,6 +258,10 @@ function switchVisualizer(evt: Event){
       break;
     case 'orbits':
       visualizer = new Orbits('orbits', sceneManager, audioManager, 40);
+      visualizer.init();
+      break;
+    case 'image':
+      visualizer = new ImageVisualizer('imageVisualizer', sceneManager, audioManager);
       visualizer.init();
       break;
     default:

--- a/src/main.ts
+++ b/src/main.ts
@@ -338,21 +338,27 @@ importImage?.addEventListener('click', () => {
     input.addEventListener('change', getFile, false);
     input.click();
     
-    function getFile(e){
-        const img = new Image();
-        const reader = new FileReader();
-        const file = e.target.files[0];
-        
+    function getFile(e: Event){
+      const reader = new FileReader();
+      
+      const files = (e.target as HTMLInputElement)?.files
+      
+      if(files){
+        const file = files[0];
+      
         if(!file.type.match(/image.*/)){
             console.log("not a valid image");
             return;
         }
         
         reader.onloadend = function(){
-          const newTexture = new TextureLoader().load(reader.result);
-          sceneManager.updateTexture(newTexture);
+          if(reader.result && typeof reader.result === 'string'){
+            const newTexture = new TextureLoader().load(reader.result);
+            sceneManager.updateTexture(newTexture);
+          }
         };
         reader.readAsDataURL(file);
+      }
     }
   }
 });

--- a/src/visualizations/Image.ts
+++ b/src/visualizations/Image.ts
@@ -4,6 +4,8 @@ import { AudioManager } from '../AudioManager';
 
 // TODO: allow user to import image to show on plane
 // check out https://github.com/syncopika/room-designer/blob/main/src/index.js
+// https://github.com/syncopika/room-designer/blob/main/src/index.js#L742
+// https://github.com/syncopika/room-designer/blob/main/src/index.js#L407
 
 import {
   Mesh,
@@ -15,7 +17,7 @@ import {
   DoubleSide,
 } from 'three';
 
-export class ImageVisualizer extends VisualizerBase {
+export class ImagePlane extends VisualizerBase {
   visualization: Group;
   
   constructor(name: string, sceneManager: SceneManager, audioManager: AudioManager){

--- a/src/visualizations/Image.ts
+++ b/src/visualizations/Image.ts
@@ -1,0 +1,52 @@
+import { VisualizerBase } from './VisualizerBase';
+import { SceneManager } from '../SceneManager';
+import { AudioManager } from '../AudioManager';
+
+// TODO: allow user to import image to show on plane
+// check out https://github.com/syncopika/room-designer/blob/main/src/index.js
+
+import {
+  Mesh,
+  Vector3,
+  Group,
+  PlaneGeometry,
+  MeshBasicMaterial,
+  TextureLoader,
+  DoubleSide,
+} from 'three';
+
+export class ImageVisualizer extends VisualizerBase {
+  visualization: Group;
+  
+  constructor(name: string, sceneManager: SceneManager, audioManager: AudioManager){
+    super(name, sceneManager, audioManager);
+    this.visualization = new Group();
+  }
+  
+  init(){
+    // clear the scene
+    this.scene.children.forEach(c => {
+      if(
+        !c.type.toLowerCase().includes('camera') && 
+        !c.type.toLowerCase().includes('light'))
+      {  
+        this.scene.remove(c);
+      }
+    });
+    
+        // create plane mesh to hold image
+    const planeGeometry = new PlaneGeometry(30, 30, 1, 1);
+    const planeMaterial = new MeshBasicMaterial({color: 0x00ff00, side: DoubleSide});
+    const plane = new Mesh(planeGeometry, planeMaterial);
+    this.visualization.add(plane);
+    
+    this.scene.add(this.visualization);
+    this.visualization.position.z = -25;
+    this.visualization.position.y -= 0.5;
+  }
+  
+  update(){
+    this.doPostProcessing();
+    //this.visualization.rotateY(Math.PI / 300);
+  }
+}

--- a/src/visualizations/Image.ts
+++ b/src/visualizations/Image.ts
@@ -9,11 +9,9 @@ import { AudioManager } from '../AudioManager';
 
 import {
   Mesh,
-  Vector3,
   Group,
   PlaneGeometry,
   MeshBasicMaterial,
-  TextureLoader,
   DoubleSide,
 } from 'three';
 
@@ -38,13 +36,13 @@ export class ImagePlane extends VisualizerBase {
     
         // create plane mesh to hold image
     const planeGeometry = new PlaneGeometry(30, 30, 1, 1);
-    const planeMaterial = new MeshBasicMaterial({color: 0x00ff00, side: DoubleSide});
+    const planeMaterial = new MeshBasicMaterial({color: 0xffffff, side: DoubleSide});
     const plane = new Mesh(planeGeometry, planeMaterial);
     this.visualization.add(plane);
     
     this.scene.add(this.visualization);
     this.visualization.position.z = -25;
-    this.visualization.position.y -= 0.5;
+    this.visualization.position.y += 1.5;
   }
   
   update(){

--- a/src/visualizations/VisualizerBase.ts
+++ b/src/visualizations/VisualizerBase.ts
@@ -44,6 +44,7 @@ export class VisualizerBase {
   bloomPass: UnrealBloomPass;
   afterimagePass: AfterimagePass;
   outputPass: OutputPass;
+  imageTexture: Texture | null;
   configurableParams: Record<string, ConfigurableParameterRange | ConfigurableParameterToggle>;
   
   constructor(name: string, sceneManager: SceneManager, audioManager: AudioManager){

--- a/src/visualizations/VisualizerBase.ts
+++ b/src/visualizations/VisualizerBase.ts
@@ -44,7 +44,6 @@ export class VisualizerBase {
   bloomPass: UnrealBloomPass;
   afterimagePass: AfterimagePass;
   outputPass: OutputPass;
-  imageTexture: Texture | null;
   configurableParams: Record<string, ConfigurableParameterRange | ConfigurableParameterToggle>;
   
   constructor(name: string, sceneManager: SceneManager, audioManager: AudioManager){


### PR DESCRIPTION
This PR: 
- adds image upload functionality so that an image can be used as a texture! it's available via a button in the sidebar.
- a new "visualizer" (visualizer but not really since currently it's just a static image 😆) that shows an image on a plane in case the user just wants to show an image with audio, which utilizes the new image upload functionality. The image upload ability also extends to the other visualizers as well (most of them at least, e.g. it'll have no effect for the blob visualizer).

Maybe in the future there'll be some more fancy features for this new static image visualizer but for now it's super basic.

![image](https://github.com/user-attachments/assets/891fceac-c058-436c-8a48-f860c588d228)

you can also use the bloom filter + change mesh color with the image visualizer for some simple color enhancements to the image (like a filter)
![image](https://github.com/user-attachments/assets/355b11b7-0464-48db-92de-9a73fabfb1db)
