### PR TITLE
add configurable params for 'image' visualizer

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,6 +107,7 @@
       top: 0;
       left: 0;
       z-index: 10;
+      overflow-y: auto;
     }
     
     .drawer h1 {

--- a/src/SceneManager.ts
+++ b/src/SceneManager.ts
@@ -119,7 +119,6 @@ export class SceneManager {
   
   updateTexture(texture: Texture | null){
     if(texture !== null){
-      console.log("updating texture");
       this.scene.children.forEach(child => {
         if(child.type === 'Group'){
           (child.children as Mesh[]).forEach(c => {
@@ -137,7 +136,6 @@ export class SceneManager {
         }
       });
     }else if(texture === null){
-      // remove texture and set bg color
       this.scene.children.forEach(child => {
         if(child.type === 'Group'){
           (child.children as Mesh[]).forEach(c => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -331,7 +331,7 @@ toggleWireframeCheckbox?.addEventListener('change', () => {
 });
 
 importImage?.addEventListener('click', () => {
-  // import image, create texture, apply it to all children of scene via SceneManager
+  // import image, create texture, apply it to all children of scene
   if(sceneManager){
     const input = document.createElement('input');
     input.type = 'file';
@@ -364,8 +364,7 @@ importImage?.addEventListener('click', () => {
 });
 
 removeImage?.addEventListener('click', () => {
-  // remove texture from all children of scene via SceneManager
-  // set color of all children to current selected color
+  // remove texture from all children of scene
   if(sceneManager){
     sceneManager.updateTexture(null);
   }

--- a/src/visualizations/Image.ts
+++ b/src/visualizations/Image.ts
@@ -1,9 +1,12 @@
-import { VisualizerBase } from './VisualizerBase';
+import {
+  VisualizerBase,
+  ConfigurableParameterRange,
+  ConfigurableParameterToggle,
+} from './VisualizerBase';
 import { SceneManager } from '../SceneManager';
 import { AudioManager } from '../AudioManager';
 
-// TODO: allow user to import image to show on plane
-// check out https://github.com/syncopika/room-designer/blob/main/src/index.js
+// allow user to import image to show on plane
 // https://github.com/syncopika/room-designer/blob/main/src/index.js#L742
 // https://github.com/syncopika/room-designer/blob/main/src/index.js#L407
 
@@ -21,6 +24,16 @@ export class ImagePlane extends VisualizerBase {
   constructor(name: string, sceneManager: SceneManager, audioManager: AudioManager){
     super(name, sceneManager, audioManager);
     this.visualization = new Group();
+    
+    const params: Record<string, ConfigurableParameterRange> = {
+      'xPos': {value: 0, min: -15, max: 15, step: 0.5},
+      'yPos': {value: 1.5, min: -15, max: 15, step: 0.5},
+      'zPos': {value: -25, min: -50, max: 10, step: 0.5},
+      'xScale': {value: 1, min: 0.2, max: 3, step: 0.1},
+      'yScale': {value: 1, min: 0.2, max: 3, step: 0.1},
+    };
+    
+    Object.keys(params).forEach(p => this.configurableParams[p] = params[p]);
   }
   
   init(){
@@ -34,7 +47,7 @@ export class ImagePlane extends VisualizerBase {
       }
     });
     
-        // create plane mesh to hold image
+    // create plane mesh to hold image
     const planeGeometry = new PlaneGeometry(30, 30, 1, 1);
     const planeMaterial = new MeshBasicMaterial({color: 0xffffff, side: DoubleSide});
     const plane = new Mesh(planeGeometry, planeMaterial);
@@ -48,5 +61,14 @@ export class ImagePlane extends VisualizerBase {
   update(){
     this.doPostProcessing();
     //this.visualization.rotateY(Math.PI / 300);
+    
+    const params = this.configurableParams;
+    this.visualization.position.x = (params.xPos as ConfigurableParameterRange).value;
+    this.visualization.position.y = (params.yPos as ConfigurableParameterRange).value;
+    this.visualization.position.z = (params.zPos as ConfigurableParameterRange).value;
+    
+    const xScale = (params.xScale as ConfigurableParameterRange).value;
+    const yScale = (params.yScale as ConfigurableParameterRange).value;
+    this.visualization.scale.set(xScale, yScale, 1);
   }
 }

--- a/src/visualizations/Image.ts
+++ b/src/visualizations/Image.ts
@@ -1,7 +1,6 @@
 import {
   VisualizerBase,
   ConfigurableParameterRange,
-  ConfigurableParameterToggle,
 } from './VisualizerBase';
 import { SceneManager } from '../SceneManager';
 import { AudioManager } from '../AudioManager';


### PR DESCRIPTION
This PR adds some configurable parameters (xPos, yPos, zPos, xScale, yScale) for the static image visualizer (see drawer in screenshot) and also cleans up some leftover comments from last time.

![image](https://github.com/user-attachments/assets/77c01922-d797-45d3-acbb-930e9517f4e4)
