### PR TITLE
add automatic stop recording functionality based on imported audio duration

### DIFF
--- a/src/AudioManager.ts
+++ b/src/AudioManager.ts
@@ -7,6 +7,7 @@ export class AudioManager {
   audioSource:             AudioBufferSourceNode;
   audioFileUrl = '';
   isPlaying = false;
+  audioDurationInMs = 0;
   
   constructor(){
     // set up web audio stuff
@@ -32,11 +33,14 @@ export class AudioManager {
     req.open("GET", url, true);
     req.responseType = 'arraybuffer';
     req.onload = () => {
-      this.audioContext.decodeAudioData(req.response, (buffer) => {
+      this.audioContext.decodeAudioData(req.response, (buffer: AudioBuffer) => {
         if (!this.audioSource.buffer) this.audioSource.buffer = buffer;
         this.audioSource.connect(this.analyser);
         this.audioSource.connect(this.audioContext.destination);
         this.audioSource.connect(this.mediaStreamDestination);
+        
+        // https://stackoverflow.com/questions/71118040/getting-the-duration-of-an-mp3-file-in-a-variable
+        this.audioDurationInMs = buffer.duration * 1000; // convert to ms
       });
     };
     


### PR DESCRIPTION
This PR:
- adds automatic recording stopping based on the imported audio's duration so you don't have to manually stop it yourself!
  - i.e. if you're recording, you can just leave it on the page and walk away to do something else and ideally recording should stop automatically when the audio ends. one thing to note is that if you change tabs while recording, the visualization will not keep animating and will be stuck on the same frame as it was when you left the tab (so unfortunately you can't switch tabs while recording, unless you want a still image :D).
- now setting canvas border to green when recording checkbox is checked and border to red when playing + recording
![image](https://github.com/user-attachments/assets/5feffbd9-ab3b-4640-8168-6c127933aaef)

![image](https://github.com/user-attachments/assets/3fd9c688-ac03-4ddb-a36c-f84819181576)
