### PR TITLE
Add waveform visual in toolbar area

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,8 +166,9 @@
     
     #waveformCanvas {
       border: 1px solid #000;
-      margin: 0 auto;
-      width: 10%;
+      margin: 8px auto;
+      width: 50%;
+      height: 50px;
     }
     
   </style>

--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
-<!doctype html>
+<!DOCTYPE html>
 
 <html>
 
 <head>
-  <meta charset="utf-8" />
+  <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>music visualizer web app</title>
   <style>
@@ -164,6 +164,12 @@
       margin-left: auto;
     }
     
+    #waveformCanvas {
+      border: 1px solid #000;
+      margin: 0 auto;
+      width: 10%;
+    }
+    
   </style>
 </head>
 
@@ -297,6 +303,7 @@
         <input id='toggleRecordingCheckbox' type='checkbox' />
       </div>
     </div>
+    <canvas id='waveformCanvas'></canvas>
   </main>
   
   <script type="module" src="/src/main.ts">

--- a/src/AudioManager.ts
+++ b/src/AudioManager.ts
@@ -9,6 +9,11 @@ export class AudioManager {
   isPlaying = false;
   audioDurationInMs = 0;
   
+  // for displaying waveform of audio
+  waveformCanvas:             HTMLCanvasElement | null;
+  waveformDisplayAnimationId: number;
+  waveformCanvasId = 'waveformCanvas';
+  
   constructor(){
     // set up web audio stuff
     const audioCtx = new AudioContext();
@@ -23,6 +28,10 @@ export class AudioManager {
     this.analyser = analyser;
     this.buffer = buffer;
     this.mediaStreamDestination = audioStream;
+    
+    // for waveform visualization (separate from the main visualizer)
+    const waveformCanvasEl = document.getElementById(this.waveformCanvasId) as HTMLCanvasElement;
+    this.waveformCanvas = waveformCanvasEl;
   }
   
   loadAudioFile(url: string){
@@ -104,6 +113,7 @@ export class AudioManager {
     if(!this.isPlaying){
       this.audioSource?.start();
       this.isPlaying = true;
+      this.doWaveformVisualization();
     }
   }
   
@@ -122,5 +132,48 @@ export class AudioManager {
     
     // also update buffer accordingly
     this.buffer = new Uint8Array(this.analyser.frequencyBinCount);
+  }
+  
+  doWaveformVisualization(){
+    if(this.waveformCanvas === null || !this.isPlaying){
+      console.log('stopping waveform animation');
+      cancelAnimationFrame(this.waveformDisplayAnimationId);
+      return;
+    }
+    
+    const canvasCtx = this.waveformCanvas.getContext('2d');
+    const width = (this.waveformCanvas as HTMLCanvasElement).width;
+    const height = (this.waveformCanvas as HTMLCanvasElement).height;
+    const bufferLen = this.analyser.frequencyBinCount;
+    const dataArray = new Uint8Array(bufferLen);
+    
+    if(canvasCtx){
+        this.analyser.getByteTimeDomainData(dataArray);
+        canvasCtx.fillStyle = 'rgb(200, 200, 200)';
+        canvasCtx.fillRect(0, 0, width, height);
+        canvasCtx.lineWidth = 2;
+        canvasCtx.strokeStyle = 'rgb(0, 0, 0)';
+        canvasCtx.beginPath();
+        
+        const sliceWidth = width / bufferLen;
+        let xPos = 0;
+        
+        for(let i = 0; i < bufferLen; i++){
+            const dataVal = dataArray[i] / 128.0; // why 128?
+            const yPos = dataVal * (height/2);
+            
+            if(i === 0){
+                canvasCtx!.moveTo(xPos, yPos);
+            }else{
+                canvasCtx!.lineTo(xPos, yPos);
+            }
+            
+            xPos += sliceWidth;
+        }
+        
+        canvasCtx.stroke();
+        
+        this.waveformDisplayAnimationId = requestAnimationFrame(this.doWaveformVisualization.bind(this));
+    }
   }
 }

--- a/src/AudioManager.ts
+++ b/src/AudioManager.ts
@@ -149,7 +149,7 @@ export class AudioManager {
     
     if(canvasCtx){
         this.analyser.getByteTimeDomainData(dataArray);
-        canvasCtx.fillStyle = 'rgb(200, 200, 200)';
+        canvasCtx.fillStyle = 'rgb(240, 240, 240)';
         canvasCtx.fillRect(0, 0, width, height);
         canvasCtx.lineWidth = 2;
         canvasCtx.strokeStyle = 'rgb(0, 0, 0)';


### PR DESCRIPTION
This PR adds a waveform visualization near the toolbar area!

<img width="1920" height="1043" alt="image" src="https://github.com/user-attachments/assets/5d2f03de-3a66-49a0-873c-15c35a1f3642" />

![23-07-2025_184658](https://github.com/user-attachments/assets/6bb7d839-360b-478e-948a-294e1b6a789e)


This might be useful to further help visualize any "beats" + to compare with the main visualization going on. Also it's kinda neat? :D