### PR TITLE
Add reset functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -291,6 +291,7 @@
       <button id='importAudio'> import audio </button>
       <input id='fileInput' style='display:none;' type='file' accept='audio/*'>
       <button id='playVisualization'> play </button>
+      <button id='resetVisualization'> reset </button>
       <button id='stopVisualization'> stop </button>
       <div class='visualizerSection'>
         <p> visualizer: </p>

--- a/index.html
+++ b/index.html
@@ -291,7 +291,7 @@
       <button id='importAudio'> import audio </button>
       <input id='fileInput' style='display:none;' type='file' accept='audio/*'>
       <button id='playVisualization'> play </button>
-      <button id='resetVisualization'> reset </button>
+      <button id='resetVisualization' disabled> reset </button>
       <button id='stopVisualization'> stop </button>
       <div class='visualizerSection'>
         <p> visualizer: </p>

--- a/src/AudioManager.ts
+++ b/src/AudioManager.ts
@@ -38,7 +38,7 @@ export class AudioManager {
     this.audioSource = this.audioContext.createBufferSource();
     
     const req = new XMLHttpRequest();
-    req.open("GET", url, true);
+    req.open('GET', url, true);
     req.responseType = 'arraybuffer';
     req.onload = () => {
       this.audioContext.decodeAudioData(req.response, (buffer: AudioBuffer) => {
@@ -71,7 +71,7 @@ export class AudioManager {
           }
         }
            
-        fileInput?.addEventListener("change", onFileChange, false);
+        fileInput?.addEventListener('change', onFileChange, false);
         fileInput?.click();
       }; 
     })();
@@ -102,10 +102,10 @@ export class AudioManager {
   }
   
   loadExample(){
-    const example = "/assets/080415pianobgm3popver-edit-steinway.wav";
+    const example = '/assets/080415pianobgm3popver-edit-steinway.wav';
     this.loadAudioFile(example);
     const filenameElement = document.getElementById('audioFileName');
-    if(filenameElement) filenameElement.textContent = "080415pianobgm3popver-edit-steinway.wav"; 
+    if(filenameElement) filenameElement.textContent = '080415pianobgm3popver-edit-steinway.wav'; 
   }
   
   play(){

--- a/src/SceneManager.ts
+++ b/src/SceneManager.ts
@@ -20,6 +20,7 @@ export class SceneManager {
   light: SpotLight;
   clock: Clock;
   texture: Texture | null;
+  selectedColor: string | null;
   
   constructor(container: HTMLDivElement){
     const scene = new Scene();
@@ -105,6 +106,7 @@ export class SceneManager {
   }
   
   changeVisualizationColor(color: string){
+    this.selectedColor = color;
     this.scene.children.forEach(child => {
       if(child.type === 'Group'){
         (child.children as Mesh[]).forEach(c => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,7 @@ const audioManager = new AudioManager();
 const importAudioBtn = document.getElementById('importAudio');
 const canvasContainer = document.getElementById('canvasContainer');
 const playBtn = document.getElementById('playVisualization');
+const resetBtn = document.getElementById('resetVisualization');
 const stopBtn = document.getElementById('stopVisualization');
 const vizSelect = document.getElementById('visualizerChoice');
 const toggleRecording = document.getElementById('toggleRecordingCheckbox');
@@ -167,6 +168,10 @@ function stopVisualization(){
     stopCanvasRecord();
     isRecording = false;
   }
+}
+
+function resetVisualization(){
+  if(visualizer) visualizer.init();
 }
 
 function makeBoolToggle(name: string, parameter: ConfigurableParameterToggle): HTMLElement {
@@ -353,6 +358,18 @@ audioManager.loadExample();
 // setup some event listeners for buttons and inputs
 playBtn?.addEventListener('click', playVisualization);
 stopBtn?.addEventListener('click', stopVisualization);
+resetBtn?.addEventListener('click', () => {
+  // TODO: move this functionality under visualizer params? or disable button when selecting a non-resettable visualizer?
+  const resettableViz = [
+    'starfield',
+    'lights',
+    'ripples',
+  ];
+  if(visualizer && resettableViz.includes(visualizer.name)){
+    console.log('resetting visualization');
+    resetVisualization();
+  }
+});
 vizSelect?.addEventListener('change', switchVisualizer);
 
 toggleRecording?.addEventListener(
@@ -425,8 +442,8 @@ importImageBtn?.addEventListener('click', () => {
         const file = files[0];
       
         if(!file.type.match(/image.*/)){
-            console.log("not a valid image");
-            return;
+          console.log("not a valid image");
+          return;
         }
         
         reader.onloadend = function(){

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,13 @@ let expectedStopTime: number | null = null; // should be record start time + dur
 
 const audioManager = new AudioManager();
 
+// visualizers that can be reset (because the placement of their objects is randomized)
+const resettableViz = [
+  'starfield',
+  'lights',
+  'ripples',
+];
+
 // html elements
 const importAudioBtn = document.getElementById('importAudio');
 const canvasContainer = document.getElementById('canvasContainer');
@@ -349,6 +356,13 @@ function switchVisualizer(evt: Event){
   if(toggleWireframeCheckbox) (toggleWireframeCheckbox as HTMLInputElement).checked = false;
   
   if(visualizer) displayVisualizerConfigurableParams(visualizer);
+  
+  // disable reset button if selected visualizer is not one of resettableViz
+  if(resettableViz.includes(selected)){
+    (resetBtn as HTMLButtonElement).disabled = false;
+  }else{
+    (resetBtn as HTMLButtonElement).disabled = true;
+  }
 }
 
 // start
@@ -360,13 +374,7 @@ playBtn?.addEventListener('click', playVisualization);
 stopBtn?.addEventListener('click', stopVisualization);
 resetBtn?.addEventListener('click', () => {
   // TODO: move this functionality under visualizer params? or disable button when selecting a non-resettable visualizer?
-  const resettableViz = [
-    'starfield',
-    'lights',
-    'ripples',
-  ];
   if(visualizer && resettableViz.includes(visualizer.name)){
-    console.log('resetting visualization');
     resetVisualization();
   }
 });

--- a/src/visualizations/CircularCubes.ts
+++ b/src/visualizations/CircularCubes.ts
@@ -47,9 +47,10 @@ export class CircularCubes extends VisualizerBase {
     const angle = 360 / numObjects;
     let currAngle = 0;
 
-    function createVisualizationCube(){
+    const createVisualizationCube = (): Mesh => {
       const boxGeometry = new BoxGeometry(0.4, 0.4, 0.4);
-      const boxMaterial = new MeshPhongMaterial({color: '#ffffdd'}); // TODO: color gradient?
+      const color = this.sceneManager.selectedColor ? this.sceneManager.selectedColor : '#ffffdd';
+      const boxMaterial = new MeshPhongMaterial({color}); // TODO: color gradient?
       const box = new Mesh(boxGeometry, boxMaterial);
       box.receiveShadow = true;
       box.castShadow = true;

--- a/src/visualizations/Lights.ts
+++ b/src/visualizations/Lights.ts
@@ -48,6 +48,10 @@ export class Lights extends VisualizerBase {
       }
     });
     
+    if(this.visualization.children){
+      this.visualization = new Group();
+    }
+    
     const bufferLen = this.audioManager.analyser.frequencyBinCount;
     const numObjects = this.numObjects;
     

--- a/src/visualizations/Lights.ts
+++ b/src/visualizations/Lights.ts
@@ -59,9 +59,12 @@ export class Lights extends VisualizerBase {
     // so Math.floor(bufferLen / numObjects) may end up being 0
     const increment = Math.max(1, Math.floor(bufferLen / numObjects));
     
-    const createVisualizationSphere = () => {
+    const createVisualizationSphere = (): Mesh => {
       const geometry = new SphereGeometry(10, 28, 16);
-      const material = new MeshStandardMaterial({color: '#2ff109', transparent: true});
+      
+      const color = this.sceneManager.selectedColor ? this.sceneManager.selectedColor : '#2ff109';
+      
+      const material = new MeshStandardMaterial({color, transparent: true});
       const sphere = new Mesh(geometry, material);
       
       sphere.position.set(

--- a/src/visualizations/Orbits.ts
+++ b/src/visualizations/Orbits.ts
@@ -62,9 +62,10 @@ export class Orbits extends VisualizerBase {
     // so Math.floor(bufferLen / numObjects) may end up being 0
     const increment = Math.max(1, Math.floor(bufferLen / numObjects));
     
-    const createVisualizationSphere = () => {
+    const createVisualizationSphere = (): Mesh => {
       const geometry = new SphereGeometry(10, 28, 16);
-      const material = new MeshPhongMaterial({color: '#2f88f5', transparent: true});
+      const color = this.sceneManager.selectedColor ? this.sceneManager.selectedColor : '#2f88f5';
+      const material = new MeshPhongMaterial({color, transparent: true});
       const sphere = new Mesh(geometry, material);
       
       const scale = Math.random() * (0.085 - 0.045) + 0.045;

--- a/src/visualizations/Ripples.ts
+++ b/src/visualizations/Ripples.ts
@@ -31,6 +31,13 @@ export class Ripples extends VisualizerBase {
     this.scaleTo = [];
     this.objectNonShaderMaterial = [];
     this.objectShaderMaterial = [];
+    
+    // add new configurable param for toggling material opacity
+    this.configurableParams.toggleMaterialOpacity = {isOn: true, parameterName: 'toggleMaterialOpacity'};
+    
+    // add new configurable param for toggling shader or non-shader material
+    // the shader material gives the closest 'ripple' effect atm so it's the default
+    this.configurableParams.rippleShaderMaterialOn = {isOn: true, parameterName: 'rippleShaderMaterialOn'};
   }
   
   init(){
@@ -48,13 +55,6 @@ export class Ripples extends VisualizerBase {
       this.visualization = new Group();
     }
     
-    // add new configurable param for toggling material opacity
-    this.configurableParams.toggleMaterialOpacity = {isOn: true, parameterName: 'toggleMaterialOpacity'};
-    
-    // add new configurable param for toggling shader or non-shader material
-    // the shader material gives the closest 'ripple' effect atm so it's the default
-    this.configurableParams.rippleShaderMaterialOn = {isOn: true, parameterName: 'rippleShaderMaterialOn'};
-    
     // fix z-position of light (otherwise the ripples will look black)
     // TODO: make sure light control slider for z axis is adjusted!
     this.sceneManager.light.position.z = 50;
@@ -68,8 +68,8 @@ export class Ripples extends VisualizerBase {
     
     const createRipple = (position: Vector3): Mesh => {
       const geometry = new CircleGeometry(5, 32);
-      
-      const material = new MeshPhongMaterial({color: '#2f88f5', transparent: true});
+      const color = this.sceneManager.selectedColor ? this.sceneManager.selectedColor : '#2f88f5';
+      const material = new MeshPhongMaterial({color, transparent: true});
       this.objectNonShaderMaterial.push(material);
       
       const shaderMaterial = new ShaderMaterial({

--- a/src/visualizations/Ripples.ts
+++ b/src/visualizations/Ripples.ts
@@ -44,6 +44,10 @@ export class Ripples extends VisualizerBase {
       }
     });
     
+    if(this.visualization.children){
+      this.visualization = new Group();
+    }
+    
     // add new configurable param for toggling material opacity
     this.configurableParams.toggleMaterialOpacity = {isOn: true, parameterName: 'toggleMaterialOpacity'};
     

--- a/src/visualizations/Spheres.ts
+++ b/src/visualizations/Spheres.ts
@@ -44,7 +44,8 @@ export class Spheres extends VisualizerBase {
     
     const createVisualizationSphere = (position: Vector3): Mesh => {
       const geometry = new SphereGeometry(10, 28, 16);
-      const material = new MeshPhongMaterial({color: '#2f88f5', transparent: true});
+      const color = this.sceneManager.selectedColor ? this.sceneManager.selectedColor : '#2f88f5';
+      const material = new MeshPhongMaterial({color, transparent: true});
       const sphere = new Mesh(geometry, material);
       
       sphere.position.copy(position.normalize());

--- a/src/visualizations/SphericalCubes.ts
+++ b/src/visualizations/SphericalCubes.ts
@@ -45,7 +45,8 @@ export class SphericalCubes extends VisualizerBase {
     
     const createVisualizationCube = (position: Vector3): Mesh => {
       const boxGeometry = new BoxGeometry(0.4, 0.4, 0.4);
-      const boxMaterial = new MeshPhongMaterial({color: '#ffffdd'}); // TODO: color gradient?
+      const color = this.sceneManager.selectedColor ? this.sceneManager.selectedColor : '#ffffdd';
+      const boxMaterial = new MeshPhongMaterial({color}); // TODO: color gradient?
       const box = new Mesh(boxGeometry, boxMaterial);
       box.receiveShadow = true;
       box.castShadow = true;

--- a/src/visualizations/Starfield.ts
+++ b/src/visualizations/Starfield.ts
@@ -231,6 +231,10 @@ export class Starfield extends VisualizerBase {
       }
     });
     
+    if(this.visualization.children){
+      this.visualization = new Group();
+    }
+    
     // load gltf model of star
     const starGltf = await this.loadModel('/assets/star.gltf');
     const starModel: Mesh = (starGltf as GLTFFile).scene.children[0] as Mesh;

--- a/src/visualizations/Waveform.ts
+++ b/src/visualizations/Waveform.ts
@@ -46,9 +46,10 @@ export class Waveform extends VisualizerBase {
     const xIncrement = 0.93;
     let xPos = -25;
 
-    function createVisualizationCube(){
+    const createVisualizationCube = (): Mesh => {
       const boxGeometry = new BoxGeometry(0.4, 0.4, 0.4);
-      const boxMaterial = new MeshPhongMaterial({color: '#aaff00'});
+      const color = this.sceneManager.selectedColor ? this.sceneManager.selectedColor : '#aaff00';
+      const boxMaterial = new MeshPhongMaterial({color});
       const box = new Mesh(boxGeometry, boxMaterial);
       box.receiveShadow = true;
       box.castShadow = true;

--- a/src/visualizations/Waveform.ts
+++ b/src/visualizations/Waveform.ts
@@ -30,14 +30,14 @@ export class Waveform extends VisualizerBase {
       if(
         !c.type.toLowerCase().includes('camera') && 
         !c.type.toLowerCase().includes('light'))
-      {  
+      {
         this.scene.remove(c);
       }
     });
     
     const bufferLen = this.audioManager.analyser.frequencyBinCount;
 
-    const numObjects = this.numObjects;
+    const numObjects = this.numObjects; // TODO: not sure numObjects is accurate naming here?
     
     // if a small analyser.fftSize is chosen, frequencyBinCount will be small as well and
     // so Math.floor(bufferLen / numObjects) may end up being 0

--- a/src/visualizations/Waves.ts
+++ b/src/visualizations/Waves.ts
@@ -74,9 +74,10 @@ export class Waves extends VisualizerBase {
     const zSeparation = params.zSeparation as ConfigurableParameterRange;
     const yPos = params.yPos as ConfigurableParameterRange;
 
-    function createVisualizationCube(): Mesh {
+    const createVisualizationCube = (): Mesh => {
       const boxGeometry = new BoxGeometry(0.1, 0.1, 0.1);
-      const boxMaterial = new MeshBasicMaterial({color: '#ffffdd'}); // TODO: color gradient?
+      const color = this.sceneManager.selectedColor ? this.sceneManager.selectedColor : '#ffffdd';
+      const boxMaterial = new MeshBasicMaterial({color}); // TODO: color gradient?
       const box = new Mesh(boxGeometry, boxMaterial);
       box.receiveShadow = true;
       box.castShadow = true;


### PR DESCRIPTION
This PR: 
- adds reset functionality for visualizers that consist of meshes placed randomly (e.g. ripples, lights, starfield)
  - visualizers that can't be reset will have the button to do so disabled
- makes color changes persistent across visualizers (so if you pick a color for one visualizer, you can switch to another visualizer and it should also take the selected color)

![09-02-2026_183321](https://github.com/user-attachments/assets/21235f34-30ab-406c-a4ff-8da0dd235157)


