### PR TITLE
more ripple visualizer improvements

### DIFF
--- a/src/visualizations/Ripples.ts
+++ b/src/visualizations/Ripples.ts
@@ -1,4 +1,8 @@
-import { ConfigurableParameterToggle, VisualizerBase } from './VisualizerBase';
+import {
+  ConfigurableParameterToggle,
+  ConfigurableParameterRange,
+  VisualizerBase,
+} from './VisualizerBase';
 import { SceneManager } from '../SceneManager';
 import { AudioManager } from '../AudioManager';
 
@@ -39,6 +43,15 @@ export class Ripples extends VisualizerBase {
     // add new configurable param for toggling shader or non-shader material
     // the shader material gives the closest 'ripple' effect atm so it's the default
     this.configurableParams.rippleShaderMaterialOn = {isOn: true, parameterName: 'rippleShaderMaterialOn'};
+    
+    // add new slider param for customizing number of ripple "stripe"
+    this.configurableParams.rippleShaderNumStripes = {
+      value: 60.0,
+      min: 1.0,
+      max: 100.0,
+      step: 1.0,
+      parameterName: 'rippleShaderNumStripes',
+    };
   }
   
   changeVisualizationColor(color: string){
@@ -97,14 +110,13 @@ export class Ripples extends VisualizerBase {
           uniform float uOpacity;
           uniform vec3 uColor;
           uniform float uTime;
+          uniform float uNumStripes;
           
           void main() {
             // distance from center
             float strength = distance(vUv, vec2(0.5));
             
-            float numStripes = 60.0; // changing this value produces interesting results!
-            
-            float sign = sin(strength * numStripes + uTime); // used to determine stripe color
+            float sign = sin(strength * uNumStripes + uTime); // used to determine stripe color
             
             // the alpha color of the circle will be based on distance from center
             // the closer to the center of the circle, the more transparent
@@ -121,6 +133,7 @@ export class Ripples extends VisualizerBase {
           uOpacity: {value: 1.0},
           uColor: {value: new Color(color)}, // some kind of blue by default
           uTime: {value: 1.0},
+          uNumStripes: {value: (this.configurableParams.rippleShaderNumStripes as ConfigurableParameterRange).value},
         },
         transparent: true, // necessary for alpha channel
       });
@@ -203,29 +216,6 @@ export class Ripples extends VisualizerBase {
           .normalize()
           .multiplyScalar(valToScaleTo * 1.5); // TODO: make this factor adjustable?
         
-        // idea: ripple meshes should always continue expanding up to a certain point and then start over at a radius of 0
-        // if lerpTo results in a smaller scale than the current scale,
-        // make the scale increase only by a tiny amount
-        /*
-        if(lerpTo.y < obj.scale.y){
-          obj.scale.lerpVectors(
-            obj.scale,
-            new Vector3(obj.scale.x * 1.01, obj.scale.y * 1.01, obj.scale.z),
-            lerpAmount,
-          );
-        }else{
-          obj.scale.lerpVectors(
-            obj.scale,
-            lerpTo,
-            lerpAmount * 1.2,
-          );
-        }
-        
-        if(obj.scale.y >= this.maxScaleY){
-          obj.scale.x = 0.1;
-          obj.scale.y = 0.1;
-        }*/
-        
         obj.scale.lerpVectors(
           obj.scale,
           lerpTo,
@@ -246,6 +236,7 @@ export class Ripples extends VisualizerBase {
           
           // make the stripes of the ripple meshes move based on time
           shaderMat.uniforms.uTime.value = elapsedTime * lerpTo.y;
+          shaderMat.uniforms.uNumStripes.value = (this.configurableParams.rippleShaderNumStripes as ConfigurableParameterRange).value;
         }else{
           (obj as Mesh).material = this.objectNonShaderMaterial[i];
         }

--- a/src/visualizations/Ripples.ts
+++ b/src/visualizations/Ripples.ts
@@ -96,23 +96,31 @@ export class Ripples extends VisualizerBase {
           varying vec2 vUv;
           uniform float uOpacity;
           uniform vec3 uColor;
+          uniform float uTime;
           
           void main() {
             // distance from center
             float strength = distance(vUv, vec2(0.5));
             
-            //float ringColor = sin(strength * 30.0);
+            float numStripes = 60.0; // changing this value produces interesting results!
+            
+            float sign = sin(strength * numStripes + uTime); // used to determine stripe color
             
             // the alpha color of the circle will be based on distance from center
             // the closer to the center of the circle, the more transparent
-            float alpha = smoothstep(0.4, 0.6, strength);
+            float alpha = smoothstep(0.2, 0.6, strength);
             
-            gl_FragColor = vec4(uColor.r, uColor.g, uColor.b, alpha * uOpacity);
+            if(sign > 0.0){
+              gl_FragColor = vec4(uColor.r, uColor.g, uColor.b, alpha * uOpacity);
+            }else{
+              gl_FragColor = vec4(0.0, 0.0, 0.0, 0.0); // transparent stripe
+            }
           }
         `,
         uniforms: {
           uOpacity: {value: 1.0},
           uColor: {value: new Color(color)}, // some kind of blue by default
+          uTime: {value: 1.0},
         },
         transparent: true, // necessary for alpha channel
       });
@@ -231,10 +239,13 @@ export class Ripples extends VisualizerBase {
           const shaderMat = (obj as Mesh).material as ShaderMaterial;
           if(lerpTo.y < obj.scale.y){
             // if ripple is getting smaller/not expanding, make it less opaque to help emphasize the ripple expansion
-            shaderMat.uniforms.uOpacity.value = 0.2 * lerpTo.y;
+            shaderMat.uniforms.uOpacity.value = 0.3 * lerpTo.y;
           }else{
             shaderMat.uniforms.uOpacity.value = 1.0;
           }
+          
+          // make the stripes of the ripple meshes move based on time
+          shaderMat.uniforms.uTime.value = elapsedTime * lerpTo.y;
         }else{
           (obj as Mesh).material = this.objectNonShaderMaterial[i];
         }


### PR DESCRIPTION
I think with these changes, now it should look a lot more like ripples lol. 

I had been missing 2 key ideas: striping (alternating between a color and fully transparent) + animating those stripes based on time to better simulate ripples. Of course there's probably more to it but I think those things at least gives the foundation needed to better simulate a ripple effect.

><img width="1577" height="874" alt="16-05-2026_080629" src="https://github.com/user-attachments/assets/5def2cb2-e75a-4c85-bf80-fa64baa718ec" />

also made number of "stripes" configurable so it's more interesting! :D  

><img width="1712" height="937" alt="16-05-2026_095417" src="https://github.com/user-attachments/assets/d023eea8-6fb3-4139-a961-025fe172f232" />
