### PR TITLE
add functionality to stream audio from different tab for visualization

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,6 +294,7 @@
       <button id='playVisualization'> play </button>
       <button id='resetVisualization' disabled> reset </button>
       <button id='stopVisualization'> stop </button>
+      <button id='streamAudioFromDifferentTab'>stream audio from different tab</button>
       <div class='visualizerSection'>
         <p> visualizer: </p>
         <select id='visualizerChoice'>

--- a/src/AudioManager.ts
+++ b/src/AudioManager.ts
@@ -120,7 +120,7 @@ export class AudioManager {
   
   play(){
     if(!this.isPlaying){
-      this.audioSource?.start();
+      if(this.audioSource instanceof AudioBufferSourceNode) this.audioSource?.start();
       this.isPlaying = true;
       this.doWaveformVisualization();
     }
@@ -128,7 +128,13 @@ export class AudioManager {
   
   stop(){
     if(this.isPlaying){
-      this.audioSource?.stop();
+      if(this.audioSource instanceof AudioBufferSourceNode){
+        this.audioSource?.stop();
+      }else{
+        // assuming MediaStreamSource
+        this.audioSource?.disconnect();
+      }
+      
       this.isPlaying = false;
       
       // reload since we can't restart buffer source

--- a/src/AudioManager.ts
+++ b/src/AudioManager.ts
@@ -3,7 +3,7 @@ export class AudioManager {
   mediaStreamDestination:  MediaStreamAudioDestinationNode
   analyser:                AnalyserNode;
   buffer:                  Uint8Array;
-  audioSource:             AudioBufferSourceNode;
+  audioSource:             AudioBufferSourceNode | MediaStreamAudioSourceNode;
   audioFileUrl = '';
   isPlaying = false;
   audioDurationInMs = 0;
@@ -12,6 +12,9 @@ export class AudioManager {
   waveformCanvas:             HTMLCanvasElement | null;
   waveformDisplayAnimationId: number;
   waveformCanvasId = 'waveformCanvas';
+  
+  // for streaming audio from a different tab
+  differentTabAudioStream: MediaStream | null;
   
   constructor(){
     // set up web audio stuff
@@ -41,11 +44,13 @@ export class AudioManager {
     req.open('GET', url, true);
     req.responseType = 'arraybuffer';
     req.onload = () => {
+      const currAudioSrc = this.audioSource as AudioBufferSourceNode;
+      
       this.audioContext.decodeAudioData(req.response, (buffer: AudioBuffer) => {
-        if (!this.audioSource.buffer) this.audioSource.buffer = buffer;
-        this.audioSource.connect(this.analyser);
-        this.audioSource.connect(this.audioContext.destination);
-        this.audioSource.connect(this.mediaStreamDestination);
+        if (!currAudioSrc.buffer) currAudioSrc.buffer = buffer;
+        currAudioSrc.connect(this.analyser);
+        currAudioSrc.connect(this.audioContext.destination);
+        currAudioSrc.connect(this.mediaStreamDestination);
         
         // https://stackoverflow.com/questions/71118040/getting-the-duration-of-an-mp3-file-in-a-variable
         this.audioDurationInMs = buffer.duration * 1000; // convert to ms
@@ -56,13 +61,18 @@ export class AudioManager {
   };
   
   async streamFromDifferentTab(){
-    const stream = await navigator.mediaDevices.getDisplayMedia({video: true, audio: true});
-    this.audioSource = this.audioContext.createMediaStreamSource(stream);
-    this.audioSource.connect(this.analyser);
-    this.audioSource.connect(this.audioContext.destination);
-    this.audioSource.connect(this.mediaStreamDestination);
-    this.isPlaying = true;
-    this.doWaveformVisualization();
+    if(!this.isPlaying){
+      const stream = await navigator.mediaDevices.getDisplayMedia({video: true, audio: true});
+      this.audioSource = this.audioContext.createMediaStreamSource(stream);
+      this.audioSource.connect(this.analyser);
+      this.audioSource.connect(this.audioContext.destination);
+      this.audioSource.connect(this.mediaStreamDestination);
+      this.isPlaying = true;
+      this.doWaveformVisualization();
+      this.differentTabAudioStream = stream;
+    }else{
+      console.log('already streaming audio from a different tab.');
+    }
   }
   
   // stuff for loading in an audio file.
@@ -70,8 +80,6 @@ export class AudioManager {
   setupInput(button: HTMLButtonElement){
     const openFile = (function(){
       return function(handleFileFunc: (f: File) => void){
-        //if(isPlaying) return;
-           
         const fileInput = document.getElementById('fileInput');
            
         function onFileChange(evt: Event){
@@ -133,6 +141,12 @@ export class AudioManager {
       }else{
         // assuming MediaStreamSource
         this.audioSource?.disconnect();
+        
+        if(this.differentTabAudioStream){
+          // stop streaming
+          this.differentTabAudioStream.getTracks().forEach(track => track.stop());
+          this.differentTabAudioStream = null;
+        }
       }
       
       this.isPlaying = false;

--- a/src/AudioManager.ts
+++ b/src/AudioManager.ts
@@ -19,13 +19,13 @@ export class AudioManager {
     const analyser = audioCtx.createAnalyser(); // default fft size is 2048
     const bufferLength = analyser.frequencyBinCount;
     const buffer = new Uint8Array(bufferLength);
+        
+    this.audioContext = audioCtx;
+    this.analyser = analyser;
+    this.buffer = buffer; // used for collecting audio data from analyser node
     
     // for recording
     const audioStream = audioCtx.createMediaStreamDestination();
-    
-    this.audioContext = audioCtx;
-    this.analyser = analyser;
-    this.buffer = buffer;
     this.mediaStreamDestination = audioStream;
     
     // for waveform visualization (separate from the main visualizer)
@@ -54,6 +54,16 @@ export class AudioManager {
     
     req.send();
   };
+  
+  async streamFromDifferentTab(){
+    const stream = await navigator.mediaDevices.getDisplayMedia({video: true, audio: true});
+    this.audioSource = this.audioContext.createMediaStreamSource(stream);
+    this.audioSource.connect(this.analyser);
+    this.audioSource.connect(this.audioContext.destination);
+    this.audioSource.connect(this.mediaStreamDestination);
+    this.isPlaying = true;
+    this.doWaveformVisualization();
+  }
   
   // stuff for loading in an audio file.
   // TODO: can this stuff be simplified? seems like a bit much

--- a/src/main.ts
+++ b/src/main.ts
@@ -396,7 +396,6 @@ streamAudioFromDifferentTabBtn?.addEventListener('click', () => {
   if(audioManager){
     audioManager.streamFromDifferentTab();
     isPlaying = true;
-    // TODO: do we need to do anything with the play/stop buttons?
   }
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -185,6 +185,19 @@ function resetVisualization(){
   if(visualizer) visualizer.init();
 }
 
+function streamAudioFromDifferentTab(){
+  if(audioManager){
+    audioManager.streamFromDifferentTab();
+    isPlaying = true;
+    
+    if(recordingOn && !isRecording){
+      console.log('starting record');
+      startCanvasRecord(renderer);
+      isRecording = true;
+    }
+  }
+}
+
 function makeBoolToggle(name: string, parameter: ConfigurableParameterToggle): HTMLElement {
   const div = document.createElement('div');
   div.className = 'input';
@@ -392,12 +405,7 @@ resetBtn?.addEventListener('click', () => {
 });
 vizSelect?.addEventListener('change', switchVisualizer);
 
-streamAudioFromDifferentTabBtn?.addEventListener('click', () => {
-  if(audioManager){
-    audioManager.streamFromDifferentTab();
-    isPlaying = true;
-  }
-});
+streamAudioFromDifferentTabBtn?.addEventListener('click', streamAudioFromDifferentTab);
 
 toggleRecording?.addEventListener(
   'change', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,7 @@ const canvasContainer = document.getElementById('canvasContainer');
 const playBtn = document.getElementById('playVisualization');
 const resetBtn = document.getElementById('resetVisualization');
 const stopBtn = document.getElementById('stopVisualization');
+const streamAudioFromDifferentTabBtn = document.getElementById('streamAudioFromDifferentTab');
 const vizSelect = document.getElementById('visualizerChoice');
 const toggleRecording = document.getElementById('toggleRecordingCheckbox');
 const loadingMsg = document.getElementById('loadingMsg');
@@ -390,6 +391,13 @@ resetBtn?.addEventListener('click', () => {
   }
 });
 vizSelect?.addEventListener('change', switchVisualizer);
+
+streamAudioFromDifferentTabBtn?.addEventListener('click', () => {
+  if(audioManager){
+    audioManager.streamFromDifferentTab();
+    // TODO: do we need to do anything with the play/stop buttons?
+  }
+});
 
 toggleRecording?.addEventListener(
   'change', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -395,6 +395,7 @@ vizSelect?.addEventListener('change', switchVisualizer);
 streamAudioFromDifferentTabBtn?.addEventListener('click', () => {
   if(audioManager){
     audioManager.streamFromDifferentTab();
+    isPlaying = true;
     // TODO: do we need to do anything with the play/stop buttons?
   }
 });


### PR DESCRIPTION
I discovered that we can leverage the MediaDevices API via `navigator.mediaDevices.getDisplayMedia` to stream audio from a different tab, e.g. a tab with a YouTube video playing, to this app and use that audio data for the visualizations! :D 

It's super easy to do and very cool!

> <img width="1776" height="1001" alt="25-05-2026_103451" src="https://github.com/user-attachments/assets/f5d4d686-0b73-4ab2-bfe7-99c2b239b346" />
(the YouTube video I used here is: Nun ruhen alle Wälder, BWV 392 - https://www.youtube.com/watch?v=A6HgxXu4ZkM)


This is still kinda experimental/proof-of-concept though and there are a couple things to note:
- the recording functionality can get pretty laggy when using streamed audio (I think this is where offscreen web workers for handling the visualization stuff might be a big help)
  - also the audio quality seems degraded (underwater-y/bass and any instrumental background audio seem heavily reduced - almost as if just vocals are getting isolated) + you can hear still hear the audio from the tab it's being streamed from
- you have to interact with the app (e.g. press the play button first when the page is loaded) first to get things to work per https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia#security (`transient user activation` is required)