### PR TITLE
add color cubes visualizer

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,6 +303,7 @@
           <option> line-waveform </option>
           <option> starfield </option>
           <option> pixels </option>
+          <option> color-cubes </option>
           <option> circular-cubes </option>
           <option> spherical-cubes </option>
           <option> blob </option>

--- a/src/AudioManager.ts
+++ b/src/AudioManager.ts
@@ -65,7 +65,6 @@ export class AudioManager {
       const stream = await navigator.mediaDevices.getDisplayMedia({video: true, audio: true});
       this.audioSource = this.audioContext.createMediaStreamSource(stream);
       this.audioSource.connect(this.analyser);
-      this.audioSource.connect(this.audioContext.destination);
       this.audioSource.connect(this.mediaStreamDestination);
       this.isPlaying = true;
       this.doWaveformVisualization();

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import {
   VisualizerBase, 
   ConfigurableParameterRange,
   ConfigurableParameterToggle,
+  ConfigurableParameterColor,
 } from './visualizations/VisualizerBase';
 import { Waveform } from './visualizations/Waveform';
 import { CircularWaveform } from './visualizations/CircularWaveform';
@@ -257,6 +258,31 @@ function makeSlider(name: string, parameter: ConfigurableParameterRange): HTMLEl
   return div;
 }
 
+function makeColorInput(name: string, parameter: ConfigurableParameterColor): HTMLElement {
+  const div = document.createElement('div');
+  div.className = 'input';
+  div.style.display = 'flex';
+  div.style.alignItems = 'center';
+
+  const label = document.createElement('label');
+  label.textContent = name;
+  label.htmlFor = `${name}-input`;
+  
+  const input = document.createElement('input');
+  input.id = `${name}-input`;
+  input.type = 'color';
+  input.value = parameter.defaultColor;
+  
+  div.appendChild(label);
+  div.appendChild(input);
+  
+  // make sure to add the input element to parameter so the visualizer can reference it
+  // to get the current color value
+  parameter.inputElement = input;
+  
+  return div;
+}
+
 function displayVisualizerConfigurableParams(visualizer: VisualizerBase){
   // clear visualizer-specific parameter section
   visualizerOptions?.replaceChildren();
@@ -264,12 +290,14 @@ function displayVisualizerConfigurableParams(visualizer: VisualizerBase){
   // add current visualizer-specific parameters
   let currParamName = '';
   const params = Object.keys(visualizer.configurableParams);
-  params.forEach(p => {
-    const param = visualizer.configurableParams[p];
+  params.forEach(paramName => {
+    const param = visualizer.configurableParams[paramName];
     if(param?.doNotShow){
       return;
     }
     
+    // add hr element to separate parameters that don't have the same parameter name.
+    // this allows us to group parameters in the same section if we want to.
     if(param?.parameterName !== currParamName){
       visualizerOptions?.appendChild(document.createElement('hr'));
       currParamName = param.parameterName || '';
@@ -277,11 +305,15 @@ function displayVisualizerConfigurableParams(visualizer: VisualizerBase){
     
     if('isOn' in param){
       // simple on/off toggle
-      const newToggleDiv = makeBoolToggle(p, param);
+      const newToggleDiv = makeBoolToggle(paramName, param);
       visualizerOptions?.appendChild(newToggleDiv);
+    }else if('defaultColor' in param){
+      // color input
+      const colorInput = makeColorInput(paramName, (param as ConfigurableParameterColor));
+      visualizerOptions?.appendChild(colorInput);
     }else{
       // slider
-      const newSliderDiv = makeSlider(p, (param as ConfigurableParameterRange));
+      const newSliderDiv = makeSlider(paramName, (param as ConfigurableParameterRange));
       visualizerOptions?.appendChild(newSliderDiv);
     }
   });
@@ -316,7 +348,7 @@ function switchVisualizer(evt: Event){
       visualizer.init();
       break;
     case 'color-cubes':
-      visualizer = new ColorCubes('color-cubes', sceneManager, audioManager, 80);
+      visualizer = new ColorCubes('color-cubes', sceneManager, audioManager, 100);
       visualizer.init();
       break;
     case 'circular-cubes':

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import { CircularWaveform } from './visualizations/CircularWaveform';
 import { LineWaveform } from './visualizations/LineWaveform';
 import { Starfield } from './visualizations/Starfield';
 import { Pixels } from './visualizations/Pixels';
+import { ColorCubes } from './visualizations/ColorCubes';
 import { CircularCubes } from './visualizations/CircularCubes';
 import { SphericalCubes } from './visualizations/SphericalCubes';
 import { Blob as AnimatedBlob } from './visualizations/Blob';
@@ -312,6 +313,10 @@ function switchVisualizer(evt: Event){
       break;
     case 'line-waveform':
       visualizer = new LineWaveform('line-waveform', sceneManager, audioManager, 60); // pass a value n such that 360 % n == 0
+      visualizer.init();
+      break;
+    case 'color-cubes':
+      visualizer = new ColorCubes('color-cubes', sceneManager, audioManager, 80);
       visualizer.init();
       break;
     case 'circular-cubes':

--- a/src/visualizations/ColorCubes.ts
+++ b/src/visualizations/ColorCubes.ts
@@ -1,4 +1,8 @@
-import { VisualizerBase } from './VisualizerBase';
+import {
+  VisualizerBase,
+  ConfigurableParameterToggle,
+  ConfigurableParameterColor,
+} from './VisualizerBase';
 import { SceneManager } from '../SceneManager';
 import { AudioManager } from '../AudioManager';
 
@@ -27,8 +31,24 @@ export class ColorCubes extends VisualizerBase {
     this.visualization = new Group();
     this.lastTime = this.clock.getElapsedTime();
     this.scaleTo = [];
-    this.startColor = '#caf0f8';
-    this.endColor = '#023e8a';
+    this.startColor = '#023e8a';
+    this.endColor = '#caf0f8';
+    
+    // add new configurable param for toggling rotation
+    this.configurableParams.toggleRotation = {isOn: false, parameterName: 'toggleRotation'};
+    
+    // start and end color inputs for a gradient
+    this.configurableParams.startColor = {
+        parameterName: 'startColor',
+        defaultColor: this.startColor,
+        inputElement: null,
+    };
+    
+    this.configurableParams.endColor = {
+        parameterName: 'endColor',
+        defaultColor: this.endColor,
+        inputElement: null,
+    };
   }
   
   init(){
@@ -49,8 +69,9 @@ export class ColorCubes extends VisualizerBase {
     // so Math.floor(bufferLen / numObjects) may end up being 0
     const increment = Math.max(1, Math.floor(bufferLen / numObjects));
     
-    // TODO: hook this up with this.startColor (and make another one for endColor)?
-    const defaultColor = '#ffffdd';
+    // for now, the default visualizer color picker will have no effect since this visualizer is kinda
+    // special in that it features the ability to choose a start and end color (for a gradient).
+    const defaultColor = '#023e8a';
     if(!this.sceneManager.selectedColor && this.sceneManager.htmlColorPicker){
       this.sceneManager.htmlColorPicker.value = defaultColor;
     }
@@ -95,14 +116,21 @@ export class ColorCubes extends VisualizerBase {
     };
     
     // position the cubes in a square array
-    const xDist = 2;
-    const yDist = 2;
-    let currY = 12;
-    const rowStartX = -10;
+    // note that we're putting the cubes in order of fft buckets and assuming time frequency data
+    // which means that the data in the buffer is ordered from lowest frequencies to highest.
+    // so in this case, the cubes start from the top left to right and go from lowest to highest frequency.
+    const xDist = 3;
+    const yDist = 3;
+    let currY = 13;
+    const rowStartX = -15;
     let currX = rowStartX;
     let currRowCubeCount = 0;
     const numCubesPerRow = 10;
     for(let i = 0; i < bufferLen; i += increment){
+      if(this.numObjects === this.visualization.children.length){
+        break;
+      }
+      
       if(numCubesPerRow === currRowCubeCount){
         // we've filled out a row, move to next
         currX = rowStartX;
@@ -151,7 +179,6 @@ export class ColorCubes extends VisualizerBase {
       }
     }else{
       //const lerpAmount = (elapsedTime - this.lastTime) / timeInterval;
-      
       for(let i = 0; i < numObjects; i++){
         const value = buffer[i * increment] / 255;
         const newVal = value * 6;
@@ -178,10 +205,22 @@ export class ColorCubes extends VisualizerBase {
         //shaderMat.uniforms.uEndColor.value = new Color(this.endColor),
         shaderMat.uniforms.uFactor.value = 0.5 * lerpTo.y;
         shaderMat.uniforms.uOpacity.value = 0.3 * lerpTo.y;
+        
+        const startColorInput = (this.configurableParams.startColor as ConfigurableParameterColor).inputElement;
+        if(startColorInput){
+          shaderMat.uniforms.uStartColor.value = new Color(startColorInput.value);
+        }
+        
+        const endColorInput = (this.configurableParams.endColor as ConfigurableParameterColor).inputElement;
+        if(endColorInput){
+          shaderMat.uniforms.uEndColor.value = new Color(endColorInput.value);
+        }
       }
     }
-    
-    this.visualization.rotateY(Math.PI / 2000);
+
+    if((this.configurableParams.toggleRotation as ConfigurableParameterToggle).isOn){
+      this.visualization.rotateY(Math.PI / 2000);
+    }
     
     this.doPostProcessing();
   }

--- a/src/visualizations/ColorCubes.ts
+++ b/src/visualizations/ColorCubes.ts
@@ -1,0 +1,188 @@
+import { VisualizerBase } from './VisualizerBase';
+import { SceneManager } from '../SceneManager';
+import { AudioManager } from '../AudioManager';
+
+import {
+  Mesh,
+  BoxGeometry,
+  ShaderMaterial,
+  Vector3,
+  Group,
+  Color,
+} from 'three';
+
+export class ColorCubes extends VisualizerBase {
+  numObjects: number;
+  visualization: Group;
+  lastTime: number;
+  scaleTo: number[];
+  rotationAxis: Vector3;
+  initialPos: Vector3[];
+  startColor: string; // hex color string
+  endColor: string;   // hex color string
+  
+  constructor(name: string, sceneManager: SceneManager, audioManager: AudioManager, size: number){
+    super(name, sceneManager, audioManager);
+    this.numObjects = size;
+    this.visualization = new Group();
+    this.lastTime = this.clock.getElapsedTime();
+    this.scaleTo = [];
+    this.startColor = '#caf0f8';
+    this.endColor = '#023e8a';
+  }
+  
+  init(){
+    // clear the scene
+    this.scene.children.forEach(c => {
+      if(
+        !c.type.toLowerCase().includes('camera') && 
+        !c.type.toLowerCase().includes('light'))
+      {  
+        this.scene.remove(c);
+      }
+    });
+    
+    const bufferLen = this.audioManager.analyser.frequencyBinCount;
+    const numObjects = this.numObjects;
+    
+    // if a small analyser.fftSize is chosen, frequencyBinCount will be small as well and
+    // so Math.floor(bufferLen / numObjects) may end up being 0
+    const increment = Math.max(1, Math.floor(bufferLen / numObjects));
+    
+    // TODO: hook this up with this.startColor (and make another one for endColor)?
+    const defaultColor = '#ffffdd';
+    if(!this.sceneManager.selectedColor && this.sceneManager.htmlColorPicker){
+      this.sceneManager.htmlColorPicker.value = defaultColor;
+    }
+    
+    const createVisualizationCube = (position: Vector3): Mesh => {
+      const boxGeometry = new BoxGeometry(0.4, 0.4, 0.4);
+      const shaderMaterial = new ShaderMaterial({
+        vertexShader: `
+          varying vec2 vUv;
+          void  main() {
+            vUv = uv;
+            gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+          }
+        `,
+        fragmentShader: `
+          varying vec2 vUv;
+          uniform float uFactor;
+          uniform float uOpacity;
+          uniform vec3 uStartColor;
+          uniform vec3 uEndColor;
+          
+          void main() {
+            // lerp color given a start and end color
+            vec3 newColor = mix(uStartColor, uEndColor, uFactor);
+            gl_FragColor = vec4(newColor.r, newColor.g, newColor.b, 1.0);
+          }
+        `,
+        uniforms: {
+          uFactor: {value: 0.0},
+          uOpacity: {value: 1.0},
+          uStartColor: {value: new Color(this.startColor)},
+          uEndColor: {value: new Color(this.endColor)},
+        },
+        transparent: true, // necessary for alpha channel
+      });
+      
+      const box = new Mesh(boxGeometry, shaderMaterial);
+      
+      box.position.copy(position);
+      
+      return box;
+    };
+    
+    // position the cubes in a square array
+    const xDist = 2;
+    const yDist = 2;
+    let currY = 12;
+    const rowStartX = -10;
+    let currX = rowStartX;
+    let currRowCubeCount = 0;
+    const numCubesPerRow = 10;
+    for(let i = 0; i < bufferLen; i += increment){
+      if(numCubesPerRow === currRowCubeCount){
+        // we've filled out a row, move to next
+        currX = rowStartX;
+        currY -= yDist;
+        currRowCubeCount = 0;
+      }
+      
+      const cubePos = new Vector3(currX, currY, 0);
+      this.visualization.add(createVisualizationCube(cubePos));
+      
+      currX += xDist;
+      currRowCubeCount++;
+    }
+    
+    this.scene.add(this.visualization);
+    
+    this.visualization.position.z = -25;
+    this.visualization.position.y += 2.5;
+  }
+  
+  update(){
+    const elapsedTime = this.clock.getElapsedTime();
+    
+    const bufferLength = this.audioManager.analyser.frequencyBinCount;
+    const buffer = this.audioManager.buffer;
+    const numObjects = this.visualization.children.length;
+    const increment = Math.floor(bufferLength / numObjects);
+    
+    this.audioManager.analyser.getByteFrequencyData(buffer); //getByteTimeDomainData is cool too! :D
+    
+    const scaleToIsEmpty = this.scaleTo.length === 0;
+    const timeInterval = 0.02;
+    
+    if(elapsedTime - this.lastTime >= timeInterval){
+      this.lastTime = elapsedTime;
+      
+      for(let i = 0; i < numObjects; i++){
+        const value = buffer[i * increment] / 255;
+        const newVal = value * 6;
+
+        if(scaleToIsEmpty){
+          this.scaleTo.push(newVal);
+        }else{
+          this.scaleTo[i] = newVal;
+        }
+      }
+    }else{
+      //const lerpAmount = (elapsedTime - this.lastTime) / timeInterval;
+      
+      for(let i = 0; i < numObjects; i++){
+        const value = buffer[i * increment] / 255;
+        const newVal = value * 6;
+        const obj = this.visualization.children[i];
+        
+        let valToScaleTo;
+        
+        if(scaleToIsEmpty){
+          this.scaleTo.push(newVal);
+          valToScaleTo = newVal;
+        }else{
+          valToScaleTo = this.scaleTo[i];
+        }
+        
+        const lerpTo = new Vector3();
+        lerpTo
+          .copy(obj.scale)
+          .normalize()
+          .multiplyScalar(valToScaleTo * 1.5);
+        
+        // TODO: lerp the current color between startColor and endColor
+        const shaderMat = (obj as Mesh).material as ShaderMaterial;
+        //shaderMat.uniforms.uStartColor.value = new Color(this.startColor),
+        //shaderMat.uniforms.uEndColor.value = new Color(this.endColor),
+        shaderMat.uniforms.uFactor.value = 0.5 * lerpTo.y;
+        shaderMat.uniforms.uOpacity.value = 0.3 * lerpTo.y;
+      }
+    }
+    
+    this.visualization.rotateY(Math.PI / 2000);
+    
+    this.doPostProcessing();
+  }
+}

--- a/src/visualizations/VisualizerBase.ts
+++ b/src/visualizations/VisualizerBase.ts
@@ -34,6 +34,15 @@ export interface ConfigurableParameterToggle {
   parameterName?: string;
 }
 
+export interface ConfigurableParameterColor {
+  parameterName: string;
+  defaultColor: string;
+  doNotShow?: boolean;
+  // the inputElement will be created and set not within a visualizer but when the toolbar options are populated.
+  // then the visualizer's update() code can reference the input element
+  inputElement: HTMLInputElement | null;
+}
+
 export class VisualizerBase {
   name: string;
   sceneManager: SceneManager;
@@ -47,7 +56,7 @@ export class VisualizerBase {
   afterimagePass: AfterimagePass;
   outputPass: OutputPass;
   fxaaPass: ShaderPass;
-  configurableParams: Record<string, ConfigurableParameterRange | ConfigurableParameterToggle>;
+  configurableParams: Record<string, ConfigurableParameterRange | ConfigurableParameterToggle | ConfigurableParameterColor>;
   
   constructor(name: string, sceneManager: SceneManager, audioManager: AudioManager){
     this.name = name;


### PR DESCRIPTION
Adding a new visualizer that features color gradients and cubes!

> <img width="1462" height="975" alt="30-05-2026_081827" src="https://github.com/user-attachments/assets/5c8d28e9-33c2-494a-af94-6f6ee94ff081" />

I added a new configurable parameter specifically for color inputs so we can set a start and end color to use for a gradient!

I also fixed an issue with streaming audio from a different tab where you'd hear 2 instances of the audio playing - this was because I had connected the media stream node to the audio context destination. now only audio from the original source should be heard, but we still get the audio flowing into the visualizer :D